### PR TITLE
fix: prevent duplicate AutoConnect and setups on activity recreate

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ android {
             resValue "string", "DEFAULT_PROFILE", "profile_8"
             resValue "string", "applicationId", "org.obd.graphs.my.giulia.aa"
             applicationId "org.obd.graphs.my.giulia.aa"
-            versionCode 214
+            versionCode 218
         }
 
         giuliaPerformanceMonitor {

--- a/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
+++ b/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
@@ -151,19 +151,13 @@ class MainActivity :
         setContentView(R.layout.activity_main)
 
         screen.setupWindowManager(this)
-
         this.appBarConfiguration = getAppBarConfiguration()
 
         setupNavigationBar()
         setupBottomBarNavigation()
         setupNavigationViewNavigation()
         registerReceiver()
-
-        setupExceptionHandler()
-        setupVehicleProfiles()
-
         setupStatusPanel()
-        Network.setupConnectedNetworksCallback()
 
         progressBar {
             it.visibility = View.GONE
@@ -173,18 +167,19 @@ class MainActivity :
         lifecycle.addObserver(screenLockManager)
 
         supportActionBar?.hide()
-        setupMetricsProcessors()
         backupManager = BackupManager(this)
-        displayAppSignature(this)
-
-        navigateToLastVisitedScreen()
         validatePermissions()
+        FabButtons.setupSpeedDialView(this)
 
         if (savedInstanceState == null) {
+            setupExceptionHandler()
+            setupVehicleProfiles()
+            Network.setupConnectedNetworksCallback()
+            setupMetricsProcessors()
+            displayAppSignature(this)
+            navigateToLastVisitedScreen()
             AutoConnect.schedule(this)
         }
-
-        FabButtons.setupSpeedDialView(this)
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
+++ b/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
@@ -24,7 +24,6 @@ import android.os.Bundle
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
-import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat

--- a/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
+++ b/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
@@ -24,6 +24,7 @@ import android.os.Bundle
 import android.os.StrictMode
 import android.os.StrictMode.ThreadPolicy
 import android.os.StrictMode.VmPolicy
+import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.GravityCompat
@@ -178,7 +179,10 @@ class MainActivity :
 
         navigateToLastVisitedScreen()
         validatePermissions()
-        AutoConnect.schedule(this)
+
+        if (savedInstanceState == null) {
+            AutoConnect.schedule(this)
+        }
 
         FabButtons.setupSpeedDialView(this)
     }


### PR DESCRIPTION
When the user changes the app language, calling `activity.recreate()` 
was causing `onCreate` to run again. This unintentionally triggered 
`AutoConnect.schedule()` and registered duplicate metrics observers 
and network callbacks.

This commit wraps one-time app setup logic inside a 
`if (savedInstanceState == null)` check in MainActivity.kt.

Changes include protecting:
- AutoConnect scheduling
- setupMetricsProcessors (prevents duplicate observers)
- Network.setupConnectedNetworksCallback (prevents duplicate listeners)
- setupVehicleProfiles
- navigateToLastVisitedScreen (prevents backstack corruption)