### PR TITLE
fix(preferences): prevent dialog popup on language change

### DIFF
--- a/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
@@ -166,7 +166,7 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     it
                 )
                 if (savedInstanceState == null) {
-                    if (Log.isLoggable(LOG_KEY,Log.DEBUG)) {
+                    if (Log.isLoggable(LOG_KEY, Log.DEBUG)) {
                         Log.d(LOG_KEY, "Loading Pref Screen for key=$it. Opening the dialog window.")
                     }
 

--- a/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
@@ -161,13 +161,17 @@ class PreferencesFragment : PreferenceFragmentCompat() {
             setPreferencesFromResource(R.xml.preferences, rootKey)
         } else {
             requireArguments().getString(PREFERENCE_SCREEN_KEY)?.let {
-                Log.d(LOG_KEY, "Loading Pref Screen for key=$it")
-
                 setPreferencesFromResource(
                     R.xml.preferences,
                     it
                 )
-                openPreferenceDialogFor(it)
+                if (savedInstanceState == null) {
+                    if (Log.isLoggable(LOG_KEY,Log.DEBUG)) {
+                        Log.d(LOG_KEY, "Loading Pref Screen for key=$it. Opening the dialog window.")
+                    }
+
+                    openPreferenceDialogFor(it)
+                }
             }
         }
     }


### PR DESCRIPTION
Added a check for savedInstanceState in onCreatePreferences to ensure openPreferenceDialogFor() is only called on the initial creation. This prevents dialogs from unexpectedly reopening when the Activity is recreated, such as when changing the app language.