### PR TITLE
test(datalogger): add unit tests across query, trip, collector and co…

### DIFF
--- a/datalogger/build.gradle
+++ b/datalogger/build.gradle
@@ -2,9 +2,14 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'com.diffplug.spotless'
+    id 'jacoco'
 }
 
 apply from: "$project.rootDir/spotless.gradle"
+
+jacoco {
+    toolVersion = "0.8.11"
+}
 
 android {
     compileSdk rootProject.ext.compileSdkVersion
@@ -73,4 +78,34 @@ dependencies {
 
     // Robolectric (Critical for testing Services and Location without a device)
     testImplementation "org.robolectric:robolectric:4.11.1"
+}
+
+tasks.withType(Test).configureEach {
+    // Robolectric loads app/test classes through its own sandboxed classloader; without this,
+    // JaCoco's on-the-fly agent drops most of those classes as "no location" and coverage reads near-zero.
+    configure(extensions.getByType(JacocoTaskExtension)) {
+        includeNoLocationClasses = true
+        excludes = ['jdk.internal.*']
+    }
+}
+
+tasks.register('jacocoTestReport', JacocoReport) {
+    dependsOn 'testDebugUnitTest'
+
+    reports {
+        xml.required = true
+        html.required = true
+    }
+
+    def fileFilter = [
+        '**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*',
+        '**/*Test*.*', 'android/**/*.*', '**/*$Lambda$*.*', '**/*$inlined$*.*'
+    ]
+
+    def javaClasses = fileTree(dir: "${project.buildDir}/intermediates/javac/debug", excludes: fileFilter)
+    def kotlinClasses = fileTree(dir: "${project.buildDir}/tmp/kotlin-classes/debug", excludes: fileFilter)
+
+    classDirectories.setFrom(files([javaClasses, kotlinClasses]))
+    sourceDirectories.setFrom(files(['src/main/java']))
+    executionData.setFrom(fileTree(dir: project.buildDir, includes: ['jacoco/testDebugUnitTest.exec']))
 }

--- a/datalogger/src/test/java/org/obd/graphs/bl/DataLoggerTestSuite.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/DataLoggerTestSuite.kt
@@ -19,11 +19,55 @@ package org.obd.graphs.bl
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 import org.junit.runners.Suite.SuiteClasses
+import org.obd.graphs.bl.collector.InMemoryCarMetricsCollectorTest
+import org.obd.graphs.bl.collector.MetricTest
+import org.obd.graphs.bl.collector.MetricsBuilderTest
+import org.obd.graphs.bl.datalogger.AdjustmentsStrategyTest
+import org.obd.graphs.bl.datalogger.AutoConnectTest
+import org.obd.graphs.bl.datalogger.MetricsObserverTest
+import org.obd.graphs.bl.datalogger.ObdMetricExtTest
+import org.obd.graphs.bl.datalogger.PidDefinitionSerializerTest
+import org.obd.graphs.bl.datalogger.VehicleCapabilitiesManagerTest
+import org.obd.graphs.bl.datalogger.connectors.ConnectionManagerTest
+import org.obd.graphs.bl.extra.VehicleStatusMetricsProcessorTest
 import org.obd.graphs.bl.gps.GpsMetricsEmitterTest
+import org.obd.graphs.bl.query.DragRacingQueryStrategyTest
+import org.obd.graphs.bl.query.IndividualQueryStrategyTest
+import org.obd.graphs.bl.query.PerformanceQueryStrategyTest
+import org.obd.graphs.bl.query.QueryStrategyOrchestratorTest
+import org.obd.graphs.bl.query.QueryStrategyTest
+import org.obd.graphs.bl.query.SharedQueryStrategyTest
+import org.obd.graphs.bl.query.TripInfoQueryStrategyTest
+import org.obd.graphs.bl.trip.FileTripRepositoryTest
+import org.obd.graphs.bl.trip.TripDescParserTest
+import org.obd.graphs.bl.trip.TripModelSerializerTest
+import org.obd.graphs.bl.trip.TripVirtualScreenManagerTest
 
 @RunWith(Suite::class)
 @SuiteClasses(
     DataLoggerServiceTest::class,
-    GpsMetricsEmitterTest::class
+    GpsMetricsEmitterTest::class,
+    InMemoryCarMetricsCollectorTest::class,
+    MetricTest::class,
+    MetricsBuilderTest::class,
+    AdjustmentsStrategyTest::class,
+    AutoConnectTest::class,
+    MetricsObserverTest::class,
+    ObdMetricExtTest::class,
+    PidDefinitionSerializerTest::class,
+    VehicleCapabilitiesManagerTest::class,
+    ConnectionManagerTest::class,
+    VehicleStatusMetricsProcessorTest::class,
+    DragRacingQueryStrategyTest::class,
+    IndividualQueryStrategyTest::class,
+    PerformanceQueryStrategyTest::class,
+    QueryStrategyOrchestratorTest::class,
+    QueryStrategyTest::class,
+    SharedQueryStrategyTest::class,
+    TripInfoQueryStrategyTest::class,
+    FileTripRepositoryTest::class,
+    TripDescParserTest::class,
+    TripModelSerializerTest::class,
+    TripVirtualScreenManagerTest::class
 )
 class DataLoggerTestSuite

--- a/datalogger/src/test/java/org/obd/graphs/bl/collector/InMemoryCarMetricsCollectorTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/collector/InMemoryCarMetricsCollectorTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.collector
+
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.DataLoggerRepository
+import org.obd.graphs.bl.datalogger.Pid
+import org.obd.metrics.api.model.ObdMetric
+import org.obd.metrics.command.obd.ObdCommand
+import org.obd.metrics.diagnostic.Diagnostics
+import org.obd.metrics.diagnostic.Histogram
+import org.obd.metrics.diagnostic.HistogramSupplier
+import org.obd.metrics.diagnostic.Rate
+import org.obd.metrics.diagnostic.RateType
+import org.obd.metrics.pid.PidDefinition
+import org.obd.metrics.pid.PidDefinitionRegistry
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Optional
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class InMemoryCarMetricsCollectorTest : TestSetup() {
+
+    private val rpmPid = PidDefinition(Pid.ENGINE_SPEED_PID_ID.id, "010C", "atsh6f1", "Engine RPM", "01", "SomeCodec")
+    private val speedPid = PidDefinition(Pid.VEHICLE_SPEED_PID_ID.id, "010D", "atsh6f1", "Vehicle Speed", "01", "SomeCodec")
+
+    @MockK
+    lateinit var mockRegistry: PidDefinitionRegistry
+
+    @MockK
+    lateinit var mockDiagnostics: Diagnostics
+
+    @MockK
+    lateinit var mockHistogramSupplier: HistogramSupplier
+
+    private lateinit var collector: InMemoryCarMetricsCollector
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(DataLoggerRepository)
+
+        every { mockRegistry.findBy(rpmPid.id) } returns rpmPid
+        every { mockRegistry.findBy(speedPid.id) } returns speedPid
+        every { DataLoggerRepository.getPidDefinitionRegistry() } returns mockRegistry
+
+        every { mockHistogramSupplier.findBy(any()) } returns null
+        every { mockDiagnostics.histogram() } returns mockHistogramSupplier
+        every { DataLoggerRepository.getDiagnostics() } returns mockDiagnostics
+
+        every { DataLoggerRepository.findRateFor(any()) } returns Optional.empty()
+        every { DataLoggerRepository.findHistogramFor(any()) } returns emptyHistogram()
+
+        collector = InMemoryCarMetricsCollector()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun emptyHistogram(): Histogram =
+        mockk(relaxed = true) {
+            every { min } returns 0.0
+            every { max } returns 0.0
+            every { mean } returns 0.0
+        }
+
+    private fun metricFor(
+        pid: PidDefinition,
+        value: Any?,
+        lowerAlert: Boolean = false,
+        upperAlert: Boolean = false
+    ): ObdMetric =
+        ObdMetric
+            .builder()
+            .command(ObdCommand(pid))
+            .value(value)
+            .lowerAlert(lowerAlert)
+            .upperAlert(upperAlert)
+            .build()
+
+    @Test
+    fun `append with forceAppend adds a new metric`() {
+        collector.append(metricFor(rpmPid, 3000), forceAppend = true)
+
+        val result = collector.getMetric(rpmPid.id)
+
+        assertNotNull(result)
+        assertEquals(3000, result?.value)
+    }
+
+    @Test
+    fun `append without forceAppend ignores an unknown pid`() {
+        collector.append(metricFor(rpmPid, 3000), forceAppend = false)
+
+        assertNull(collector.getMetric(rpmPid.id))
+    }
+
+    @Test
+    fun `append with null input is a no-op`() {
+        collector.append(null, forceAppend = true)
+
+        assertTrue(collector.getMetrics(enabled = false).isEmpty())
+    }
+
+    @Test
+    fun `append updates value, rate and histogram of an existing metric`() {
+        collector.append(metricFor(rpmPid, 1000), forceAppend = true)
+
+        every { DataLoggerRepository.findRateFor(any()) } returns Optional.of(Rate(RateType.MEAN, 12.5, "rpm"))
+        val histogram =
+            mockk<Histogram>(relaxed = true) {
+                every { min } returns 800.0
+                every { max } returns 5000.0
+                every { mean } returns 2500.0
+            }
+        every { DataLoggerRepository.findHistogramFor(any()) } returns histogram
+
+        collector.append(metricFor(rpmPid, 4200), forceAppend = true)
+
+        val metric = collector.getMetric(rpmPid.id)!!
+        assertEquals(4200, metric.value)
+        assertEquals(12.5, metric.rate)
+        assertEquals(800.0, metric.min, 0.0001)
+        assertEquals(5000.0, metric.max, 0.0001)
+        assertEquals(2500.0, metric.mean, 0.0001)
+    }
+
+    @Test
+    fun `append latches lower and upper alert flags once raised`() {
+        collector.append(metricFor(rpmPid, 1000, lowerAlert = true, upperAlert = true), forceAppend = true)
+        // A subsequent, non-alerting reading should not clear the latched flags.
+        collector.append(metricFor(rpmPid, 2000, lowerAlert = false, upperAlert = false), forceAppend = true)
+
+        val metric = collector.getMetric(rpmPid.id)!!
+        assertTrue(metric.inLowerAlertRisedHist)
+        assertTrue(metric.inUpperAlertRisedHist)
+    }
+
+    @Test
+    fun `alertReset clears latched alert flags`() {
+        collector.append(metricFor(rpmPid, 1000, lowerAlert = true, upperAlert = true), forceAppend = true)
+
+        collector.alertReset()
+
+        val metric = collector.getMetric(rpmPid.id)!!
+        assertFalse(metric.inLowerAlertRisedHist)
+        assertFalse(metric.inUpperAlertRisedHist)
+    }
+
+    @Test
+    fun `applyFilter builds missing pids and exposes them as enabled`() {
+        collector.applyFilter(enabled = setOf(rpmPid.id, speedPid.id))
+
+        assertEquals(2, collector.getMetrics(enabled = true).size)
+        assertNull(collector.getMetric(rpmPid.id, enabled = false))
+    }
+
+    @Test
+    fun `applyFilter disables metrics that are no longer in the enabled set`() {
+        collector.applyFilter(enabled = setOf(rpmPid.id, speedPid.id))
+
+        collector.applyFilter(enabled = setOf(rpmPid.id))
+
+        assertEquals(1, collector.getMetrics(enabled = true).size)
+        assertNotNull(collector.getMetric(speedPid.id, enabled = false))
+        assertNull(collector.getMetric(speedPid.id, enabled = true))
+    }
+
+    @Test
+    fun `applyFilter orders visible metrics using the supplied order map`() {
+        collector.applyFilter(
+            enabled = setOf(rpmPid.id, speedPid.id),
+            order = mapOf(speedPid.id to 0, rpmPid.id to 1)
+        )
+
+        val ids = collector.getMetrics(enabled = true).map { it.pid.id }
+        assertEquals(listOf(speedPid.id, rpmPid.id), ids)
+    }
+
+    @Test
+    fun `applyFilter falls back to pid id ordering when order map is absent`() {
+        collector.applyFilter(enabled = setOf(speedPid.id, rpmPid.id), order = null)
+
+        val ids = collector.getMetrics(enabled = true).map { it.pid.id }
+        assertEquals(listOf(rpmPid.id, speedPid.id), ids)
+    }
+
+    @Test
+    fun `getMetric by Pid enum delegates to id lookup`() {
+        collector.applyFilter(enabled = setOf(Pid.ENGINE_SPEED_PID_ID.id))
+
+        assertNotNull(collector.getMetric(Pid.ENGINE_SPEED_PID_ID))
+        assertNull(collector.getMetric(Pid.VEHICLE_SPEED_PID_ID))
+    }
+
+    @Test
+    fun `getMetric returns null when enabled state does not match`() {
+        collector.applyFilter(enabled = setOf(rpmPid.id))
+
+        assertNull(collector.getMetric(rpmPid.id, enabled = false))
+        assertNotNull(collector.getMetric(rpmPid.id, enabled = true))
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/collector/MetricTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/collector/MetricTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.collector
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.obd.metrics.api.model.ObdMetric
+import org.obd.metrics.command.obd.ObdCommand
+import org.obd.metrics.pid.PidDefinition
+
+class MetricTest {
+
+    private val pidA = PidDefinition(100L, "010C", "atsh6f1", "RPM", "01", "Codec")
+
+    // Same id as pidA but every other field differs - PidDefinition's equals() is id-only,
+    // and so is ObdCommand's (by pid) and Reply's (by command), so this should still collapse
+    // into "the same metric" from Metric's point of view.
+    private val pidADifferentFields = PidDefinition(100L, "0199", "different query", "different desc", "02", "OtherCodec")
+
+    private val pidB = PidDefinition(200L, "010D", "atsh6f1", "Speed", "01", "Codec")
+
+    private fun obdMetric(pid: PidDefinition, value: Any?): ObdMetric =
+        ObdMetric.builder().command(ObdCommand(pid)).value(value).build()
+
+    @Test
+    fun `equals and hashCode depend only on the source command pid id`() {
+        val m1 = Metric.newInstance(source = obdMetric(pidA, 10), value = 10, min = 0.0, max = 100.0, mean = 50.0)
+        val m2 = Metric.newInstance(source = obdMetric(pidADifferentFields, 9999), value = 9999, min = -5.0, max = 5.0, mean = 0.0)
+
+        assertEquals(m1, m2)
+        assertEquals(m1.hashCode(), m2.hashCode())
+    }
+
+    @Test
+    fun `metrics built from different pids are not equal`() {
+        val m1 = Metric.newInstance(source = obdMetric(pidA, 1), value = 1)
+        val m2 = Metric.newInstance(source = obdMetric(pidB, 1), value = 1)
+
+        assertNotEquals(m1, m2)
+    }
+
+    @Test
+    fun `a metric is never equal to null or an unrelated type`() {
+        val metric = Metric.newInstance(source = obdMetric(pidA, 1), value = 1)
+
+        assertFalse(metric.equals(null))
+        assertFalse(metric.equals("not a metric"))
+    }
+
+    @Test
+    fun `newInstance factory defaults enabled to true and rate to zero`() {
+        val metric = Metric.newInstance(source = obdMetric(pidA, 1), value = 1)
+
+        assertTrue(metric.enabled)
+        assertEquals(0.0, metric.rate)
+    }
+
+    @Test
+    fun `newInstance factory defaults min, max and mean to zero when not supplied`() {
+        val metric = Metric.newInstance(source = obdMetric(pidA, 1), value = 1)
+
+        assertEquals(0.0, metric.min, 0.0001)
+        assertEquals(0.0, metric.max, 0.0001)
+        assertEquals(0.0, metric.mean, 0.0001)
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/collector/MetricsBuilderTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/collector/MetricsBuilderTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.collector
+
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.DataLoggerRepository
+import org.obd.graphs.bl.datalogger.Pid
+import org.obd.metrics.api.model.ObdMetric
+import org.obd.metrics.command.obd.ObdCommand
+import org.obd.metrics.diagnostic.Diagnostics
+import org.obd.metrics.diagnostic.Histogram
+import org.obd.metrics.diagnostic.HistogramSupplier
+import org.obd.metrics.pid.PidDefinition
+import org.obd.metrics.pid.PidDefinitionRegistry
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class MetricsBuilderTest : TestSetup() {
+
+    private val rpmPid = PidDefinition(Pid.ENGINE_SPEED_PID_ID.id, "010C", "atsh6f1", "Engine RPM", "01", "SomeCodec")
+    private val speedPid = PidDefinition(Pid.VEHICLE_SPEED_PID_ID.id, "010D", "atsh6f1", "Vehicle Speed", "01", "SomeCodec")
+    private val gasPid = PidDefinition(Pid.GAS_PID_ID.id, "0111", "atsh6f1", "Gas", "01", "SomeCodec")
+
+    @MockK
+    lateinit var mockRegistry: PidDefinitionRegistry
+
+    @MockK
+    lateinit var mockDiagnostics: Diagnostics
+
+    @MockK
+    lateinit var mockHistogramSupplier: HistogramSupplier
+
+    private lateinit var metricsBuilder: MetricsBuilder
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(DataLoggerRepository)
+
+        every { mockRegistry.findBy(rpmPid.id) } returns rpmPid
+        every { mockRegistry.findBy(speedPid.id) } returns speedPid
+        every { mockRegistry.findBy(gasPid.id) } returns gasPid
+        every { DataLoggerRepository.getPidDefinitionRegistry() } returns mockRegistry
+
+        every { mockHistogramSupplier.findBy(any()) } returns null
+        every { mockDiagnostics.histogram() } returns mockHistogramSupplier
+        every { DataLoggerRepository.getDiagnostics() } returns mockDiagnostics
+
+        metricsBuilder = MetricsBuilder()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun histogram(
+        min: Double,
+        max: Double,
+        mean: Double,
+        latestValue: Double?
+    ): Histogram {
+        val h = mockk<Histogram>(relaxed = true)
+        every { h.min } returns min
+        every { h.max } returns max
+        every { h.mean } returns mean
+        every { h.latestValue } returns latestValue
+        return h
+    }
+
+    @Test
+    fun `buildFor ObdMetric populates stats from the histogram when present`() {
+        every { mockHistogramSupplier.findBy(rpmPid) } returns histogram(1.0, 9.0, 5.0, 7.0)
+        val obdMetric = ObdMetric.builder().command(ObdCommand(rpmPid)).build()
+
+        val result = metricsBuilder.buildFor(obdMetric)
+
+        assertEquals(1.0, result.min, 0.0001)
+        assertEquals(9.0, result.max, 0.0001)
+        assertEquals(5.0, result.mean, 0.0001)
+        assertEquals(7.0, result.value)
+    }
+
+    @Test
+    fun `buildFor ObdMetric defaults to zero stats when no histogram exists`() {
+        val obdMetric = ObdMetric.builder().command(ObdCommand(rpmPid)).build()
+
+        val result = metricsBuilder.buildFor(obdMetric)
+
+        assertEquals(0.0, result.min, 0.0001)
+        assertEquals(0.0, result.max, 0.0001)
+        assertEquals(0.0, result.mean, 0.0001)
+        assertEquals(0, result.value)
+    }
+
+    @Test
+    fun `buildFor ids skips ids the registry cannot resolve`() {
+        val unknownId = 424242L
+        every { mockRegistry.findBy(unknownId) } returns null
+
+        val result = metricsBuilder.buildFor(setOf(rpmPid.id, unknownId))
+
+        assertEquals(1, result.size)
+        assertEquals(rpmPid.id, result[0].pid.id)
+    }
+
+    @Test
+    fun `buildFor ids without explicit order sorts by pid id ascending`() {
+        val result = metricsBuilder.buildFor(linkedSetOf(speedPid.id, rpmPid.id))
+
+        assertEquals(listOf(rpmPid.id, speedPid.id), result.map { it.pid.id })
+    }
+
+    @Test
+    fun `buildFor ids with sortOrder honors the order map and falls back to pid id for unlisted entries`() {
+        val result =
+            metricsBuilder.buildFor(
+                setOf(rpmPid.id, speedPid.id, gasPid.id),
+                sortOrder = mapOf(speedPid.id to 0)
+            )
+
+        // speedPid has an explicit order, so it always sorts first; the two unlisted ids
+        // (both implicitly Int.MAX_VALUE) fall back to comparing pid ids against each other:
+        // rpmPid.id (13) < gasPid.id (7007).
+        assertEquals(listOf(speedPid.id, rpmPid.id, gasPid.id), result.map { it.pid.id })
+    }
+
+    @Test
+    fun `buildFor ids with a null sortOrder preserves the original set iteration order`() {
+        val result = metricsBuilder.buildFor(linkedSetOf(speedPid.id, rpmPid.id, gasPid.id), sortOrder = null)
+
+        assertEquals(listOf(speedPid.id, rpmPid.id, gasPid.id), result.map { it.pid.id })
+    }
+
+    @Test
+    fun `buildDiff copies max minus min into the rebuilt source but the returned value still comes from the histogram`() {
+        val sourceMetric =
+            Metric.newInstance(
+                source = ObdMetric.builder().command(ObdCommand(rpmPid)).value(42).build(),
+                value = 42,
+                min = 10.0,
+                max = 90.0,
+                mean = 50.0
+            )
+
+        val diff = metricsBuilder.buildDiff(sourceMetric)
+
+        // buildDiff() feeds `max - min` into ObdMetric.value(), but buildFor(ObdMetric) always
+        // re-derives the final Metric.value from the histogram lookup (0, since none is stubbed here) -
+        // the diff value only ever survives inside the rebuilt source ObdMetric.
+        assertEquals(80.0, diff.source.value)
+        assertEquals(0, diff.value)
+    }
+
+    @Test
+    fun `buildDiff sets a null source value when the original metric had no reading`() {
+        val sourceMetric =
+            Metric.newInstance(
+                source = ObdMetric.builder().command(ObdCommand(rpmPid)).value(null).build(),
+                value = 0,
+                min = 10.0,
+                max = 90.0,
+                mean = 50.0
+            )
+
+        val diff = metricsBuilder.buildDiff(sourceMetric)
+
+        assertNull(diff.source.value)
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/datalogger/AdjustmentsStrategyTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/datalogger/AdjustmentsStrategyTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.query.QueryStrategyType
+import org.obd.metrics.pid.PIDsGroup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class AdjustmentsStrategyTest : TestSetup() {
+
+    private val strategy = AdjustmentsStrategy()
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+        every { context.cacheDir } returns File("/tmp")
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun preferences(stnEnabled: Boolean = false) =
+        DataLoggerSettings(
+            debugLogging = true,
+            dragRacingCommandFrequency = 25,
+            fuelTankSize = 70,
+            dumpRawConnectorResponse = true,
+            adapter =
+            Adapter(
+                maxReconnectNum = 3,
+                reconnectWhenError = true,
+                batchEnabled = true,
+                batchStrictValidationEnabled = true,
+                calculateResponseFrames = true,
+                mode01BatchSize = 10,
+                otherModesBatchSize = 20,
+                commandFrequency = 15,
+                adaptiveConnectionEnabled = true,
+                stnExtensionsEnabled = stnEnabled,
+                stnIgnorePIDsPriorities = true,
+                continueOnError = true,
+                connectionType = "bluetooth",
+                vehicleMetadataReadingEnabled = true,
+                vehicleCapabilitiesReadingEnabled = true,
+                dtcEnabled = true,
+                dtcAutoCleanup = true,
+                resultsCacheEnabled = true
+            )
+        )
+
+    @Test
+    fun `default adjustments are built from the shared preferences`() {
+        val preferences = preferences()
+        every { dataLoggerSettings.instance() } returns preferences
+
+        val adjustments = strategy.findAdjustmentFor(QueryStrategyType.SHARED_QUERY, preferences)
+
+        assertTrue(adjustments.isDebugEnabled)
+        assertEquals(3, adjustments.errorsPolicy.numberOfRetries)
+        assertTrue(adjustments.errorsPolicy.isReconnectEnabled)
+        assertTrue(adjustments.errorsPolicy.isContinueOnError)
+        assertTrue(adjustments.batchPolicy.isEnabled)
+        assertTrue(adjustments.batchPolicy.isStrictValidationEnabled)
+        assertEquals(10, adjustments.batchPolicy.mode01BatchSize)
+        assertEquals(20, adjustments.batchPolicy.otherModesBatchSize)
+        assertEquals(70, adjustments.formulaExternalParams.params["unit_tank_size"])
+        assertTrue(adjustments.isCollectRawConnectorResponseEnabled)
+        assertEquals(15L, adjustments.adaptiveTimeoutPolicy.commandFrequency)
+        assertTrue(adjustments.requestedGroups.contains(PIDsGroup.METADATA))
+        assertTrue(adjustments.requestedGroups.contains(PIDsGroup.CAPABILITES))
+        assertTrue(adjustments.requestedGroups.contains(PIDsGroup.DTC_READ))
+        assertTrue(adjustments.requestedGroups.contains(PIDsGroup.DTC_CLEAR))
+    }
+
+    @Test
+    fun `drag racing adjustments disable vehicle metadata and capabilities reading`() {
+        val preferences = preferences()
+        every { dataLoggerSettings.instance() } returns preferences
+
+        val adjustments = strategy.findAdjustmentFor(QueryStrategyType.DRAG_RACING_QUERY, preferences)
+
+        assertTrue(adjustments.isDebugEnabled)
+        assertEquals(25L, adjustments.adaptiveTimeoutPolicy.commandFrequency)
+        assertFalse(adjustments.isCollectRawConnectorResponseEnabled)
+        assertTrue(adjustments.requestedGroups.isEmpty())
+        assertFalse(adjustments.cachePolicy.isResultCacheEnabled)
+    }
+
+    @Test
+    fun `drag racing adjustments add priority overrides when stn extensions are enabled`() {
+        val preferences = preferences(stnEnabled = true)
+        every { dataLoggerSettings.instance() } returns preferences
+
+        val adjustments = strategy.findAdjustmentFor(QueryStrategyType.DRAG_RACING_QUERY, preferences)
+
+        assertTrue(adjustments.overrides.containsKey(Pid.ATM_PRESSURE_PID_ID.id))
+        assertTrue(adjustments.overrides.containsKey(Pid.AMBIENT_TEMP_PID_ID.id))
+        assertTrue(adjustments.overrides.containsKey(Pid.DYNAMIC_SELECTOR_PID_ID.id))
+        assertTrue(adjustments.overrides.containsKey(Pid.ENGINE_TORQUE_PID_ID.id))
+    }
+
+    @Test
+    fun `drag racing adjustments do not add overrides when stn extensions are disabled`() {
+        val preferences = preferences(stnEnabled = false)
+        every { dataLoggerSettings.instance() } returns preferences
+
+        val adjustments = strategy.findAdjustmentFor(QueryStrategyType.DRAG_RACING_QUERY, preferences)
+
+        assertTrue(adjustments.overrides.isEmpty())
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/datalogger/AutoConnectTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/datalogger/AutoConnectTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.Network
+import org.obd.graphs.bl.TestSetup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Robolectric gives each test method a fresh Sandbox classloader, so the [AutoConnect] object's
+ * debounce state (a static AtomicLong) is reset between test methods here.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [29])
+class AutoConnectTest : TestSetup() {
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+        mockkObject(Network)
+        every { Network.startBackgroundBleScanForMac(any(), any(), any()) } just Runs
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `schedule starts a background scan when enabled with a valid mac address on a supported SDK`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(deviceAddress = "aa:bb:cc:dd:ee:ff"))
+
+        AutoConnect.schedule(context, autoConnectEnabled = true)
+
+        verify { Network.startBackgroundBleScanForMac(context, "AA:BB:CC:DD:EE:FF", any()) }
+    }
+
+    @Test
+    fun `schedule does nothing when auto connect is disabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(deviceAddress = "aa:bb:cc:dd:ee:ff"))
+
+        AutoConnect.schedule(context, autoConnectEnabled = false)
+
+        verify(exactly = 0) { Network.startBackgroundBleScanForMac(any(), any(), any()) }
+    }
+
+    @Test
+    fun `schedule does nothing when the device address is empty`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(adapter = Adapter(deviceAddress = ""))
+
+        AutoConnect.schedule(context, autoConnectEnabled = true)
+
+        verify(exactly = 0) { Network.startBackgroundBleScanForMac(any(), any(), any()) }
+    }
+
+    @Test
+    @Config(manifest = Config.NONE, sdk = [28])
+    fun `schedule does nothing on Android versions below Q`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(deviceAddress = "aa:bb:cc:dd:ee:ff"))
+
+        AutoConnect.schedule(context, autoConnectEnabled = true)
+
+        verify(exactly = 0) { Network.startBackgroundBleScanForMac(any(), any(), any()) }
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/datalogger/MetricsObserverTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/datalogger/MetricsObserverTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.metrics.api.model.ObdMetric
+import org.obd.metrics.api.model.Reply
+import org.obd.metrics.api.model.VehicleCapabilities
+import org.obd.metrics.command.obd.ObdCommand
+import org.obd.metrics.pid.PidDefinition
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class MetricsObserverTest : TestSetup() {
+
+    private val pid = PidDefinition(100L, "010C", "atsh6f1", "RPM", "01", "Codec")
+
+    private lateinit var observer: MetricsObserver
+
+    @Before
+    override fun setup() {
+        super.setup()
+        observer = MetricsObserver()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun processor(): MetricsProcessor = mockk(relaxed = true)
+
+    @Test
+    fun `observe registers and initializes the processor`() {
+        val p = processor()
+
+        observer.observe(p)
+
+        verify(exactly = 1) { p.init(observer) }
+    }
+
+    @Test
+    fun `onNext dispatches an ObdMetric reply to all registered processors`() {
+        val processorA = processor()
+        val processorB = processor()
+        observer.observe(processorA)
+        observer.observe(processorB)
+
+        val reply = ObdMetric.builder().command(ObdCommand(pid)).value(42).build()
+        observer.onNext(reply)
+
+        verify(exactly = 1) { processorA.postValue(reply) }
+        verify(exactly = 1) { processorB.postValue(reply) }
+    }
+
+    @Test
+    fun `onNext ignores non ObdMetric replies`() {
+        val processorA = processor()
+        observer.observe(processorA)
+
+        val reply = mockk<Reply<*>>(relaxed = true)
+        observer.onNext(reply)
+
+        verify(exactly = 0) { processorA.postValue(any()) }
+    }
+
+    @Test
+    fun `onNext swallows a processor exception and still notifies the remaining processors`() {
+        val throwing = processor()
+        every { throwing.postValue(any()) } throws RuntimeException("boom")
+        val healthy = processor()
+        observer.observe(throwing)
+        observer.observe(healthy)
+
+        val reply = ObdMetric.builder().command(ObdCommand(pid)).value(1).build()
+        observer.onNext(reply)
+
+        verify(exactly = 1) { healthy.postValue(reply) }
+    }
+
+    @Test
+    fun `onStopped fans out to all registered processors`() {
+        val processorA = processor()
+        val processorB = processor()
+        observer.observe(processorA)
+        observer.observe(processorB)
+
+        observer.onStopped()
+
+        verify(exactly = 1) { processorA.onStopped() }
+        verify(exactly = 1) { processorB.onStopped() }
+    }
+
+    @Test
+    fun `onRunning fans out the same VehicleCapabilities to all registered processors`() {
+        val processorA = processor()
+        val processorB = processor()
+        observer.observe(processorA)
+        observer.observe(processorB)
+
+        val capabilities = mockk<VehicleCapabilities>(relaxed = true)
+        observer.onRunning(capabilities)
+
+        verify(exactly = 1) { processorA.onRunning(capabilities) }
+        verify(exactly = 1) { processorB.onRunning(capabilities) }
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/datalogger/ObdMetricExtTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/datalogger/ObdMetricExtTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.USER_CUSTOM_PIDS_FILE
+import org.obd.graphs.bl.TestSetup
+import org.obd.metrics.api.model.ObdMetric
+import org.obd.metrics.command.obd.ObdCommand
+import org.obd.metrics.pid.PidDefinition
+import org.obd.metrics.pid.ValueType
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class ObdMetricExtTest : TestSetup() {
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun pidWithId(id: Long): PidDefinition = PidDefinition(id, "010C", "atsh6f1", "Test PID", "01", "SomeCodec")
+
+    private fun pidWithRange(
+        id: Long,
+        min: Number,
+        max: Number
+    ): PidDefinition = PidDefinition(id, 1, "", "01", "0100", "%", "Test PID", min, max, ValueType.DOUBLE)
+
+    private fun metricFor(
+        pid: PidDefinition,
+        value: Any?
+    ): ObdMetric = ObdMetric.builder().command(ObdCommand(pid)).value(value).build()
+
+    @Test
+    fun `isAtmPressure matches only the atm pressure pid id`() {
+        assertTrue(metricFor(pidWithId(Pid.ATM_PRESSURE_PID_ID.id), 100).isAtmPressure())
+        assertFalse(metricFor(pidWithId(Pid.AMBIENT_TEMP_PID_ID.id), 100).isAtmPressure())
+    }
+
+    @Test
+    fun `isAmbientTemp matches only the ambient temp pid id`() {
+        assertTrue(metricFor(pidWithId(Pid.AMBIENT_TEMP_PID_ID.id), 20).isAmbientTemp())
+        assertFalse(metricFor(pidWithId(Pid.ATM_PRESSURE_PID_ID.id), 20).isAmbientTemp())
+    }
+
+    @Test
+    fun `isVehicleStatus matches only the vehicle status pid id`() {
+        assertTrue(metricFor(pidWithId(Pid.VEHICLE_STATUS_PID_ID.id), null).isVehicleStatus())
+        assertFalse(metricFor(pidWithId(Pid.ATM_PRESSURE_PID_ID.id), null).isVehicleStatus())
+    }
+
+    @Test
+    fun `isDynamicSelector matches only the dynamic selector pid id`() {
+        assertTrue(metricFor(pidWithId(Pid.DYNAMIC_SELECTOR_PID_ID.id), 1).isDynamicSelector())
+        assertFalse(metricFor(pidWithId(Pid.ATM_PRESSURE_PID_ID.id), 1).isDynamicSelector())
+    }
+
+    @Test
+    fun `isVehicleSpeed uses standard pid when gme extensions are disabled`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(gmeExtensionsEnabled = false)
+
+        assertTrue(metricFor(pidWithId(Pid.VEHICLE_SPEED_PID_ID.id), 50).isVehicleSpeed())
+        assertFalse(metricFor(pidWithId(Pid.EXT_VEHICLE_SPEED_PID_ID.id), 50).isVehicleSpeed())
+    }
+
+    @Test
+    fun `isVehicleSpeed uses extended pid when gme extensions are enabled`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(gmeExtensionsEnabled = true)
+
+        assertTrue(metricFor(pidWithId(Pid.EXT_VEHICLE_SPEED_PID_ID.id), 50).isVehicleSpeed())
+        assertFalse(metricFor(pidWithId(Pid.VEHICLE_SPEED_PID_ID.id), 50).isVehicleSpeed())
+    }
+
+    @Test
+    fun `isEngineRpm uses standard pid when gme extensions are disabled`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(gmeExtensionsEnabled = false)
+
+        assertTrue(metricFor(pidWithId(Pid.ENGINE_SPEED_PID_ID.id), 3000).isEngineRpm())
+        assertFalse(metricFor(pidWithId(Pid.EXT_ENGINE_SPEED_PID_ID.id), 3000).isEngineRpm())
+    }
+
+    @Test
+    fun `isEngineRpm uses extended pid when gme extensions are enabled`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(gmeExtensionsEnabled = true)
+
+        assertTrue(metricFor(pidWithId(Pid.EXT_ENGINE_SPEED_PID_ID.id), 3000).isEngineRpm())
+        assertFalse(metricFor(pidWithId(Pid.ENGINE_SPEED_PID_ID.id), 3000).isEngineRpm())
+    }
+
+    @Test
+    fun `isUserCustom is true only for the user custom pids resource file`() {
+        val pid = pidWithId(99L)
+
+        pid.resourceFile = USER_CUSTOM_PIDS_FILE
+        assertTrue(pid.isUserCustom)
+
+        pid.resourceFile = "alfa.json"
+        assertFalse(pid.isUserCustom)
+    }
+
+    @Test
+    fun `PidDefinition scaleToRange maps a 0-3500 value into the pid's own range`() {
+        val pid = pidWithRange(id = 1L, min = 0, max = 100)
+
+        // 1750 is the midpoint of the default 0..3500 range, should map to the midpoint of 0..100
+        val result = pid.scaleToRange(1750f)
+
+        assertEquals(50f, result, 0.01f)
+    }
+
+    @Test
+    fun `ObdMetric scaleToRange maps the metric value into the 0-3500 range`() {
+        val pid = pidWithRange(id = 1L, min = 0, max = 100)
+        val metric = metricFor(pid, 50)
+
+        val result = metric.scaleToRange()
+
+        assertEquals(1750f, result, 0.01f)
+    }
+
+    @Test
+    fun `ObdMetric scaleToRange falls back to 0-9999 range when pid has no min or max`() {
+        val pid = PidDefinition(1L, "010C", "atsh6f1", "Test PID", "01", "SomeCodec")
+        val metric = metricFor(pid, 100)
+
+        val result = metric.scaleToRange()
+
+        // 100.mapRange(0, 9999, 0, 3500)
+        val expected = 100f.let { (it - 0f) * (3500f - 0f) / (9999f - 0f) }
+        assertEquals(expected, result, 0.01f)
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/datalogger/PidDefinitionSerializerTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/datalogger/PidDefinitionSerializerTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger
+
+import io.mockk.every
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.metrics.pid.PidDefinition
+import org.obd.metrics.pid.ValueType
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val PREF_KEY_PREFIX = "pref.pid.registry.overrides.pid"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class PidDefinitionSerializerTest : TestSetup() {
+
+    @Before
+    override fun setup() {
+        super.setup()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    // Uses the (id, length, formula, mode, pid, units, description, min, max, type) constructor, which
+    // sets `formula` to a real (non-null) string, matching how PIDs are actually built from resource
+    // files in production. PidDefinition.formula is @NonNull, so a null formula (as left by some of the
+    // other constructors) breaks Jackson deserialization.
+    private fun pid(id: Long) = PidDefinition(id, 1, "", "01", "010C", "rpm", "Engine RPM", 0, 8000, ValueType.DOUBLE)
+
+    @Test
+    fun `serialize writes the pid as json under a per-id preference key`() {
+        val slot = slot<String>()
+        every { editor.putString(eq("$PREF_KEY_PREFIX.42"), capture(slot)) } returns editor
+
+        pid(42L).serialize()
+
+        assertTrue(slot.captured.contains("Engine RPM"))
+        verify { editor.commit() }
+    }
+
+    @Test
+    fun `deserialize reconstructs the pid from the stored json`() {
+        val slot = slot<String>()
+        every { editor.putString(eq("$PREF_KEY_PREFIX.42"), capture(slot)) } returns editor
+        pid(42L).serialize()
+
+        every { sharedPrefs.getString(eq("$PREF_KEY_PREFIX.42"), any()) } returns slot.captured
+
+        val result = pid(42L).deserialize()
+
+        assertEquals(42L, result?.id)
+        assertEquals("Engine RPM", result?.description)
+    }
+
+    @Test
+    fun `deserialize returns null when nothing is stored`() {
+        assertNull(pid(99L).deserialize())
+    }
+
+    @Test
+    fun `deserialize returns null instead of throwing on malformed json`() {
+        every { sharedPrefs.getString(eq("$PREF_KEY_PREFIX.7"), any()) } returns "{not valid json"
+
+        assertNull(pid(7L).deserialize())
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/datalogger/VehicleCapabilitiesManagerTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/datalogger/VehicleCapabilitiesManagerTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.metrics.api.model.DiagnosticTroubleCode
+import org.obd.metrics.api.model.VehicleCapabilities
+import org.obd.metrics.command.dtc.DiagnosticTroubleCodeClearStatus
+import org.obd.metrics.pid.PidDefinition
+import org.obd.metrics.pid.PidDefinitionRegistry
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val PREF_VEHICLE_SUPPORTED_PIDS = "pref.datalogger.supported.pids"
+private const val PREF_VEHICLE_METADATA = "pref.datalogger.vehicle.properties"
+private const val PREF_DTC = "pref.datalogger.dtc"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class VehicleCapabilitiesManagerTest : TestSetup() {
+
+    private fun dtc(
+        standardCode: String,
+        description: String
+    ) = DiagnosticTroubleCode().apply {
+        this.standardCode = standardCode
+        this.description = description
+    }
+
+    private fun vehicleCapabilities(
+        metadata: Map<String, String> = emptyMap(),
+        capabilities: Set<String> = emptySet(),
+        dtc: Set<DiagnosticTroubleCode> = emptySet()
+    ) = VehicleCapabilities(metadata, capabilities, dtc, DiagnosticTroubleCodeClearStatus.OK)
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+        mockkStatic("org.obd.graphs.BroadcastKt")
+        every { org.obd.graphs.sendBroadcastEvent(any<String>()) } returns Unit
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `updateCapabilities stores supported pids when reading is enabled and capabilities are present`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(vehicleCapabilitiesReadingEnabled = true, dtcEnabled = false))
+
+        val capabilities = vehicleCapabilities(metadata = mapOf("vin" to "WVW123"), capabilities = setOf("0100", "010C"))
+
+        VehicleCapabilitiesManager.updateCapabilities(capabilities)
+
+        verify { editor.putStringSet(PREF_VEHICLE_SUPPORTED_PIDS, capabilities.capabilities) }
+        verify { editor.putString(eq(PREF_VEHICLE_METADATA), any()) }
+    }
+
+    @Test
+    fun `updateCapabilities does not store supported pids when reading is disabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(vehicleCapabilitiesReadingEnabled = false, dtcEnabled = false))
+
+        val capabilities = vehicleCapabilities(capabilities = setOf("0100"))
+
+        VehicleCapabilitiesManager.updateCapabilities(capabilities)
+
+        verify(exactly = 0) { editor.putStringSet(eq(PREF_VEHICLE_SUPPORTED_PIDS), any()) }
+    }
+
+    @Test
+    fun `updateCapabilities broadcasts DTC available only when dtc reading is enabled and dtc is not empty`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(vehicleCapabilitiesReadingEnabled = false, dtcEnabled = true))
+
+        val capabilities = vehicleCapabilities(dtc = setOf(dtc("P0100", "Mass air flow circuit")))
+
+        VehicleCapabilitiesManager.updateCapabilities(capabilities)
+
+        verify { org.obd.graphs.sendBroadcastEvent(DATA_LOGGER_DTC_AVAILABLE) }
+    }
+
+    @Test
+    fun `updateCapabilities does not broadcast when dtc reading is disabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(vehicleCapabilitiesReadingEnabled = false, dtcEnabled = false))
+
+        val capabilities = vehicleCapabilities(dtc = setOf(dtc("P0100", "Mass air flow circuit")))
+
+        VehicleCapabilitiesManager.updateCapabilities(capabilities)
+
+        verify(exactly = 0) { org.obd.graphs.sendBroadcastEvent(DATA_LOGGER_DTC_AVAILABLE) }
+    }
+
+    @Test
+    fun `updateDTC and getDiagnosticTroubleCodes round trip through preferences`() {
+        val slot = slot<String>()
+        every { editor.putString(eq(PREF_DTC), capture(slot)) } returns editor
+
+        VehicleCapabilitiesManager.updateDTC(setOf(dtc("P0100", "Mass air flow circuit")))
+
+        every { sharedPrefs.getString(eq(PREF_DTC), any()) } returns slot.captured
+
+        val result = VehicleCapabilitiesManager.getDiagnosticTroubleCodes()
+
+        assertEquals(1, result.size)
+        assertEquals("P0100", result[0].standardCode)
+    }
+
+    @Test
+    fun `getDiagnosticTroubleCodes returns an empty list instead of throwing on malformed json`() {
+        every { sharedPrefs.getString(eq(PREF_DTC), any()) } returns "not-json"
+
+        assertTrue(VehicleCapabilitiesManager.getDiagnosticTroubleCodes().isEmpty())
+    }
+
+    @Test
+    fun `getVehicleMetadata returns an empty list when nothing is stored`() {
+        assertTrue(VehicleCapabilitiesManager.getVehicleMetadata().isEmpty())
+    }
+
+    @Test
+    fun `getVehicleMetadata parses the stored metadata map`() {
+        every { sharedPrefs.getString(eq(PREF_VEHICLE_METADATA), any()) } returns """{"vin":"WVW123"}"""
+
+        val result = VehicleCapabilitiesManager.getVehicleMetadata()
+
+        assertEquals(1, result.size)
+        assertEquals("vin", result[0].name)
+        assertEquals("WVW123", result[0].value)
+    }
+
+    @Test
+    fun `getSupportedPIDs returns the stored pids`() {
+        mockkObject(DataLoggerRepository)
+        val mockRegistry = mockk<PidDefinitionRegistry>()
+        val pid1 = PidDefinition(1L, "0100", "atsh6f1", "Supported PIDs", "01", "SomeCodec")
+        val pid2 = PidDefinition(2L, "010C", "atsh6f1", "Engine RPM", "01", "SomeCodec")
+        every { mockRegistry.findAll() } returns listOf(pid1, pid2)
+        every { DataLoggerRepository.getPidDefinitionRegistry() } returns mockRegistry
+
+        every { sharedPrefs.getStringSet(eq(PREF_VEHICLE_SUPPORTED_PIDS), any()) } returns setOf("0100", "010c")
+
+        val result = VehicleCapabilitiesManager.getSupportedPIDs()
+
+        assertEquals(setOf("0100", "010c"), result.toSet())
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/datalogger/connectors/ConnectionManagerTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/datalogger/connectors/ConnectionManagerTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger.connectors
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.Network
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.Adapter
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_ADAPTER_NOT_SET_EVENT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_WIFI_INCORRECT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_WIFI_NOT_CONNECTED
+import org.obd.graphs.bl.datalogger.DataLoggerSettings
+import org.obd.graphs.bl.datalogger.dataLoggerSettings
+import org.obd.metrics.api.model.Adjustments
+import org.obd.metrics.api.model.Init
+import org.obd.metrics.api.model.Query
+import org.obd.metrics.pid.PidDefinitionRegistry
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class ConnectionManagerTest : TestSetup() {
+
+    private val registry = mockk<PidDefinitionRegistry>(relaxed = true)
+    private val query = mockk<Query>(relaxed = true)
+    private val adjustments = mockk<Adjustments>(relaxed = true)
+    private val init = mockk<Init>(relaxed = true)
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+        mockkObject(Network)
+        mockkStatic("org.obd.graphs.BroadcastKt")
+        every { org.obd.graphs.sendBroadcastEvent(any<String>()) } returns Unit
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun settingsWith(connectionType: String, adapter: Adapter = Adapter()) {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = adapter.copy(connectionType = connectionType))
+    }
+
+    @Test
+    fun `obtain returns null for an unknown connection type`() {
+        settingsWith("none")
+
+        val result = ConnectionManager.obtain(registry, query, adjustments, init)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `bluetooth connection is rejected and broadcasts when device address is empty`() {
+        settingsWith("bluetooth", Adapter(deviceAddress = ""))
+
+        val result = ConnectionManager.obtain(registry, query, adjustments, init)
+
+        assertNull(result)
+        verify { org.obd.graphs.sendBroadcastEvent(DATA_LOGGER_ADAPTER_NOT_SET_EVENT) }
+    }
+
+    @Test
+    fun `bluetooth connection is rejected and broadcasts when the adapter cannot be found`() {
+        settingsWith("bluetooth", Adapter(deviceAddress = "AA:BB:CC:DD:EE:FF"))
+        every { Network.findBluetoothAdapterByName("AA:BB:CC:DD:EE:FF") } returns null
+
+        val result = ConnectionManager.obtain(registry, query, adjustments, init)
+
+        assertNull(result)
+        verify { org.obd.graphs.sendBroadcastEvent(DATA_LOGGER_ADAPTER_NOT_SET_EVENT) }
+    }
+
+    @Test
+    fun `wifi connection is rejected and broadcasts when not connected to any wifi network`() {
+        settingsWith("wifi", Adapter(wifiSSID = "MyHomeWifi"))
+        every { Network.currentSSID } returns null
+
+        val result = ConnectionManager.obtain(registry, query, adjustments, init)
+
+        assertNull(result)
+        verify { org.obd.graphs.sendBroadcastEvent(DATA_LOGGER_WIFI_NOT_CONNECTED) }
+    }
+
+    @Test
+    fun `wifi connection is rejected and broadcasts when connected to the wrong ssid`() {
+        settingsWith("wifi", Adapter(wifiSSID = "MyHomeWifi"))
+        every { Network.currentSSID } returns "SomeOtherWifi"
+
+        val result = ConnectionManager.obtain(registry, query, adjustments, init)
+
+        assertNull(result)
+        verify { org.obd.graphs.sendBroadcastEvent(DATA_LOGGER_WIFI_INCORRECT) }
+    }
+
+    @Test
+    fun `usb connection type builds a usb connection from preferences`() {
+        settingsWith("usb")
+
+        val result = ConnectionManager.obtain(registry, query, adjustments, init)
+
+        assertNotNull(result)
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/extra/VehicleStatusMetricsProcessorTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/extra/VehicleStatusMetricsProcessorTest.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.extra
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.DataLoggerSettings
+import org.obd.graphs.bl.datalogger.Pid
+import org.obd.graphs.bl.datalogger.dataLoggerSettings
+import org.obd.graphs.sendBroadcastEvent
+import org.obd.metrics.api.model.ObdMetric
+import org.obd.metrics.command.obd.ObdCommand
+import org.obd.metrics.pid.PidDefinition
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class VehicleStatusMetricsProcessorTest : TestSetup() {
+
+    private val vehicleStatusPid = PidDefinition(Pid.VEHICLE_STATUS_PID_ID.id, "22F0", "atsh6f1", "Vehicle Status", "22", "Codec")
+    private val settings = DataLoggerSettings()
+
+    private lateinit var processor: VehicleStatusMetricsProcessor
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+        every { dataLoggerSettings.instance() } returns settings
+
+        mockkStatic("org.obd.graphs.BroadcastKt")
+        every { sendBroadcastEvent(any<String>()) } just Runs
+
+        settings.vehicleStatusPanelEnabled = true
+        settings.vehicleStatusDisconnectWhenOff = false
+
+        processor = VehicleStatusMetricsProcessor()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun statusMetric(
+        engineRunning: Boolean,
+        vehicleRunning: Boolean,
+        keyStatusOn: Boolean,
+        accelerating: Boolean = false,
+        decelerating: Boolean = false
+    ): ObdMetric =
+        ObdMetric
+            .builder()
+            .command(ObdCommand(vehicleStatusPid))
+            .value(
+                mapOf(
+                    "engine.running" to engineRunning,
+                    "vehicle.running" to vehicleRunning,
+                    "key.status" to keyStatusOn,
+                    "vehicle.accelerating" to accelerating,
+                    "vehicle.decelerating" to decelerating
+                )
+            ).build()
+
+    @Test
+    fun `engine and vehicle running fires the RUNNING event`() {
+        processor.postValue(statusMetric(engineRunning = true, vehicleRunning = true, keyStatusOn = true))
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_RUNNING) }
+    }
+
+    @Test
+    fun `engine running but vehicle stationary fires the IDLING event`() {
+        processor.postValue(statusMetric(engineRunning = true, vehicleRunning = false, keyStatusOn = true))
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_IDLING) }
+    }
+
+    @Test
+    fun `nothing running and key off fires IGNITION_OFF`() {
+        // The processor's initial state is already engine=off/vehicle=off/key=off, so the very
+        // first reading needs to move away from that state first, otherwise the change-detection
+        // guard sees no diff and fires nothing - establish a running state, then transition to off.
+        processor.postValue(statusMetric(engineRunning = true, vehicleRunning = true, keyStatusOn = true))
+
+        processor.postValue(statusMetric(engineRunning = false, vehicleRunning = false, keyStatusOn = false))
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_IGNITION_OFF) }
+    }
+
+    @Test
+    fun `nothing running and key on fires IGNITION_ON`() {
+        processor.postValue(statusMetric(engineRunning = false, vehicleRunning = false, keyStatusOn = true))
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_IGNITION_ON) }
+    }
+
+    @Test
+    fun `accelerating flag fires the ACCELERATING event alongside the state event`() {
+        processor.postValue(
+            statusMetric(engineRunning = true, vehicleRunning = true, keyStatusOn = true, accelerating = true)
+        )
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_RUNNING) }
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_ACCELERATING) }
+    }
+
+    @Test
+    fun `decelerating flag fires the DECELERATING event alongside the state event`() {
+        processor.postValue(
+            statusMetric(engineRunning = true, vehicleRunning = false, keyStatusOn = true, decelerating = true)
+        )
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_IDLING) }
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_DECELERATING) }
+    }
+
+    @Test
+    fun `repeated identical state does not re-fire events, but a state change does`() {
+        processor.postValue(statusMetric(engineRunning = true, vehicleRunning = true, keyStatusOn = true))
+        processor.postValue(statusMetric(engineRunning = true, vehicleRunning = true, keyStatusOn = true))
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_RUNNING) }
+
+        processor.postValue(statusMetric(engineRunning = true, vehicleRunning = false, keyStatusOn = true))
+
+        verify(exactly = 1) { sendBroadcastEvent(EVENT_VEHICLE_STATUS_VEHICLE_IDLING) }
+    }
+
+    @Test
+    fun `does nothing when both status panel and disconnect flags are disabled`() {
+        settings.vehicleStatusPanelEnabled = false
+        settings.vehicleStatusDisconnectWhenOff = false
+
+        processor.postValue(statusMetric(engineRunning = true, vehicleRunning = true, keyStatusOn = true))
+
+        verify(exactly = 0) { sendBroadcastEvent(any<String>()) }
+    }
+
+    @Test
+    fun `ignores metrics that are not the vehicle status pid`() {
+        val otherPid = PidDefinition(9999L, "0100", "q", "Other", "01", "Codec")
+        val metric = ObdMetric.builder().command(ObdCommand(otherPid)).value(42).build()
+
+        processor.postValue(metric)
+
+        verify(exactly = 0) { sendBroadcastEvent(any<String>()) }
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/query/DragRacingQueryStrategyTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/query/DragRacingQueryStrategyTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.query
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.PREF_DYNAMIC_SELECTOR_ENABLED
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.Adapter
+import org.obd.graphs.bl.datalogger.DataLoggerSettings
+import org.obd.graphs.bl.datalogger.Pid
+import org.obd.graphs.bl.datalogger.dataLoggerSettings
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class DragRacingQueryStrategyTest : TestSetup() {
+
+    private lateinit var strategy: DragRacingQueryStrategy
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+        every { sharedPrefs.getBoolean(PREF_DYNAMIC_SELECTOR_ENABLED, false) } returns false
+        strategy = DragRacingQueryStrategy()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `getPIDs returns basic speed and rpm pids when GME extensions are disabled`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(gmeExtensionsEnabled = false)
+
+        assertEquals(setOf(Pid.VEHICLE_SPEED_PID_ID.id, Pid.ENGINE_SPEED_PID_ID.id), strategy.getPIDs())
+    }
+
+    @Test
+    fun `getPIDs returns extended pids when GME extensions are enabled without STN`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(gmeExtensionsEnabled = true, adapter = Adapter(stnExtensionsEnabled = false))
+
+        val expected = setOf(
+            Pid.EXT_VEHICLE_SPEED_PID_ID.id,
+            Pid.EXT_ENGINE_SPEED_PID_ID.id,
+            Pid.INTAKE_PRESSURE_PID_ID.id,
+            Pid.ATM_PRESSURE_PID_ID.id,
+            Pid.AMBIENT_TEMP_PID_ID.id
+        )
+        assertEquals(expected, strategy.getPIDs())
+    }
+
+    @Test
+    fun `getPIDs adds torque and gas pids when STN extensions are enabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(gmeExtensionsEnabled = true, adapter = Adapter(stnExtensionsEnabled = true))
+
+        val result = strategy.getPIDs()
+
+        assertEquals(7, result.size)
+        assertTrue(result.containsAll(setOf(Pid.ENGINE_TORQUE_PID_ID.id, Pid.GAS_PID_ID.id)))
+    }
+
+    @Test
+    fun `getPIDs adds the dynamic selector pid when its preference is enabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(gmeExtensionsEnabled = true, adapter = Adapter(stnExtensionsEnabled = false))
+        every { sharedPrefs.getBoolean(PREF_DYNAMIC_SELECTOR_ENABLED, false) } returns true
+
+        assertTrue(strategy.getPIDs().contains(Pid.DYNAMIC_SELECTOR_PID_ID.id))
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/query/IndividualQueryStrategyTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/query/IndividualQueryStrategyTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.query
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.PREF_DYNAMIC_SELECTOR_ENABLED
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.Pid
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class IndividualQueryStrategyTest : TestSetup() {
+
+    private lateinit var strategy: IndividualQueryStrategy
+
+    @Before
+    override fun setup() {
+        super.setup()
+        strategy = IndividualQueryStrategy()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `getPIDs does not add the dynamic selector pid when the preference is disabled`() {
+        every { sharedPrefs.getBoolean(PREF_DYNAMIC_SELECTOR_ENABLED, false) } returns false
+        strategy.update(setOf(1L, 2L))
+
+        assertEquals(setOf(1L, 2L), strategy.getPIDs())
+    }
+
+    @Test
+    fun `getPIDs adds the dynamic selector pid when the preference is enabled, keeping prior pids`() {
+        every { sharedPrefs.getBoolean(PREF_DYNAMIC_SELECTOR_ENABLED, false) } returns true
+        strategy.update(setOf(1L, 2L))
+
+        val result = strategy.getPIDs()
+
+        assertTrue(result.containsAll(setOf(1L, 2L, Pid.DYNAMIC_SELECTOR_PID_ID.id)))
+        assertEquals(3, result.size)
+    }
+
+    @Test
+    fun `getPIDs does not duplicate the dynamic selector pid across repeated calls`() {
+        every { sharedPrefs.getBoolean(PREF_DYNAMIC_SELECTOR_ENABLED, false) } returns true
+
+        strategy.getPIDs()
+        val result = strategy.getPIDs()
+
+        assertEquals(1, result.count { it == Pid.DYNAMIC_SELECTOR_PID_ID.id })
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/query/PerformanceQueryStrategyTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/query/PerformanceQueryStrategyTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.query
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val PERFORMANCE_QUERY_PREF_KEY = "pref.aa.performance.pids.selected"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class PerformanceQueryStrategyTest : TestSetup() {
+
+    @Before
+    override fun setup() {
+        super.setup()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `getDefaultPIDs combines top, bottom and brake boosting pids`() {
+        every { sharedPrefs.getStringSet(PREF_QUERY_PERFORMANCE_TOP, any()) } returns setOf("10", "11")
+        every { sharedPrefs.getStringSet(PREF_QUERY_PERFORMANCE_BOTTOM, any()) } returns setOf("20")
+        every { sharedPrefs.getInt(PREF_QUERY_PERFORMANCE_BRAKE_BOOSTING_GAS_METRIC, -1) } returns 30
+        every { sharedPrefs.getInt(PREF_QUERY_PERFORMANCE_BRAKE_BOOSTING_ARBITRARY_METRIC, -1) } returns 31
+        every { sharedPrefs.getInt(PREF_QUERY_PERFORMANCE_BRAKE_BOOSTING_VEHICLE_SPEED_METRIC, -1) } returns 32
+
+        val strategy = PerformanceQueryStrategy()
+
+        assertEquals(setOf(10L, 11L, 20L, 30L, 31L, 32L), strategy.getDefaultPIDs())
+    }
+
+    @Test
+    fun `getDefaultPIDs falls back to the -1 marker when brake boosting prefs are unset`() {
+        every { sharedPrefs.getStringSet(any(), any()) } returns emptySet()
+        every { sharedPrefs.getInt(any(), any()) } returns -1
+
+        val strategy = PerformanceQueryStrategy()
+
+        assertEquals(setOf(-1L), strategy.getDefaultPIDs())
+    }
+
+    @Test
+    fun `getPIDs reads from the performance selection preference`() {
+        every { sharedPrefs.getStringSet(PERFORMANCE_QUERY_PREF_KEY, any()) } returns setOf("100", "200")
+
+        val strategy = PerformanceQueryStrategy()
+
+        assertEquals(setOf(100L, 200L), strategy.getPIDs())
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/query/QueryStrategyOrchestratorTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/query/QueryStrategyOrchestratorTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.query
+
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.Adapter
+import org.obd.graphs.bl.datalogger.DataLoggerSettings
+import org.obd.graphs.bl.datalogger.Pid
+import org.obd.graphs.bl.datalogger.dataLoggerSettings
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class QueryStrategyOrchestratorTest : TestSetup() {
+
+    private lateinit var orchestrator: QueryStrategyOrchestrator
+
+    @Before
+    override fun setup() {
+        super.setup()
+        mockkObject(dataLoggerSettings)
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings()
+        orchestrator = QueryStrategyOrchestrator()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `default strategy is SHARED_QUERY`() {
+        assertEquals(QueryStrategyType.SHARED_QUERY, orchestrator.getStrategy())
+    }
+
+    @Test
+    fun `setStrategy updates the current strategy`() {
+        orchestrator.setStrategy(QueryStrategyType.PERFORMANCE_QUERY)
+        assertEquals(QueryStrategyType.PERFORMANCE_QUERY, orchestrator.getStrategy())
+    }
+
+    @Test
+    fun `getDefaultPIDs and getIDs delegate to the selected strategy`() {
+        orchestrator.setStrategy(QueryStrategyType.ROUTINES_QUERY)
+        orchestrator.update(setOf(42L))
+
+        assertEquals(setOf(42L), orchestrator.getIDs())
+        assertEquals(emptySet<Long>(), orchestrator.getDefaultPIDs())
+    }
+
+    @Test
+    fun `getIDs adds the vehicle status pid when the vehicle status panel is enabled`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(vehicleStatusPanelEnabled = true)
+        orchestrator.setStrategy(QueryStrategyType.ROUTINES_QUERY)
+
+        assertEquals(setOf(Pid.VEHICLE_STATUS_PID_ID.id), orchestrator.getIDs())
+    }
+
+    @Test
+    fun `getIDs adds the vehicle status pid when disconnect-when-off is enabled`() {
+        every { dataLoggerSettings.instance() } returns DataLoggerSettings(vehicleStatusDisconnectWhenOff = true)
+        orchestrator.setStrategy(QueryStrategyType.ROUTINES_QUERY)
+
+        assertEquals(setOf(Pid.VEHICLE_STATUS_PID_ID.id), orchestrator.getIDs())
+    }
+
+    @Test
+    fun `getIDs always strips the GPS location pid`() {
+        orchestrator.setStrategy(QueryStrategyType.ROUTINES_QUERY)
+        orchestrator.update(setOf(Pid.GPS_LOCATION_PID_ID.id, 1L))
+
+        assertEquals(setOf(1L), orchestrator.getIDs())
+    }
+
+    @Test
+    fun `filterBy returns full selection when individual query strategy is enabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(individualQueryStrategyEnabled = true))
+        every { sharedPrefs.getStringSet("some.filter.key", any()) } returns setOf("5", "6")
+
+        orchestrator.setStrategy(QueryStrategyType.ROUTINES_QUERY)
+        orchestrator.update(setOf(1L))
+
+        assertEquals(setOf(5L, 6L), orchestrator.filterBy("some.filter.key"))
+    }
+
+    @Test
+    fun `filterBy returns the intersection with current query when individual query is disabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(individualQueryStrategyEnabled = false))
+        every { sharedPrefs.getStringSet("some.filter.key", any()) } returns setOf("1", "2", "3")
+
+        orchestrator.setStrategy(QueryStrategyType.ROUTINES_QUERY)
+        orchestrator.update(setOf(2L, 3L, 4L))
+
+        assertEquals(setOf(2L, 3L), orchestrator.filterBy("some.filter.key"))
+    }
+
+    @Test
+    fun `apply(String) switches to INDIVIDUAL_QUERY and updates pids when individual query is enabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(individualQueryStrategyEnabled = true))
+        every { sharedPrefs.getStringSet("some.filter.key", any()) } returns setOf("7")
+
+        orchestrator.apply("some.filter.key")
+
+        assertEquals(QueryStrategyType.INDIVIDUAL_QUERY, orchestrator.getStrategy())
+        assertEquals(setOf(7L), orchestrator.getIDs())
+    }
+
+    @Test
+    fun `apply(String) forces SHARED_QUERY when individual query is disabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(individualQueryStrategyEnabled = false))
+
+        orchestrator.setStrategy(QueryStrategyType.PERFORMANCE_QUERY)
+        orchestrator.apply("some.filter.key")
+
+        assertEquals(QueryStrategyType.SHARED_QUERY, orchestrator.getStrategy())
+    }
+
+    @Test
+    fun `apply(Set) switches to INDIVIDUAL_QUERY and updates pids when individual query is enabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(individualQueryStrategyEnabled = true))
+
+        orchestrator.apply(setOf(8L, 9L))
+
+        assertEquals(QueryStrategyType.INDIVIDUAL_QUERY, orchestrator.getStrategy())
+        assertEquals(setOf(8L, 9L), orchestrator.getIDs())
+    }
+
+    @Test
+    fun `apply(Set) forces SHARED_QUERY when individual query is disabled`() {
+        every { dataLoggerSettings.instance() } returns
+            DataLoggerSettings(adapter = Adapter(individualQueryStrategyEnabled = false))
+
+        orchestrator.setStrategy(QueryStrategyType.PERFORMANCE_QUERY)
+        orchestrator.apply(setOf(8L, 9L))
+
+        assertEquals(QueryStrategyType.SHARED_QUERY, orchestrator.getStrategy())
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/query/QueryStrategyTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/query/QueryStrategyTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.query
+
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class QueryStrategyTest : TestSetup() {
+
+    private lateinit var strategy: QueryStrategy
+
+    @Before
+    override fun setup() {
+        super.setup()
+        strategy = QueryStrategy()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `getDefaultPIDs returns empty set by default`() {
+        assertTrue(strategy.getDefaultPIDs().isEmpty())
+    }
+
+    @Test
+    fun `getPIDs returns empty set initially`() {
+        assertTrue(strategy.getPIDs().isEmpty())
+    }
+
+    @Test
+    fun `update replaces the pids set`() {
+        strategy.update(setOf(1L, 2L, 3L))
+        assertEquals(setOf(1L, 2L, 3L), strategy.getPIDs())
+
+        strategy.update(setOf(4L))
+        assertEquals(setOf(4L), strategy.getPIDs())
+    }
+
+    @Test
+    fun `update on a constructor-seeded strategy replaces the seeded pids entirely`() {
+        val seeded = QueryStrategy(mutableSetOf(9L))
+        seeded.update(setOf(1L))
+        assertEquals(setOf(1L), seeded.getPIDs())
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/query/SharedQueryStrategyTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/query/SharedQueryStrategyTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.query
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val PREFERENCE_PID_FAST = "pref.pids.generic.high"
+private const val PREFERENCE_PID_SLOW = "pref.pids.generic.low"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class SharedQueryStrategyTest : TestSetup() {
+
+    private lateinit var strategy: SharedQueryStrategy
+
+    @Before
+    override fun setup() {
+        super.setup()
+        strategy = SharedQueryStrategy()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `getPIDs unions fast and slow pid preferences`() {
+        every { sharedPrefs.getStringSet(PREFERENCE_PID_FAST, any()) } returns setOf("1", "2")
+        every { sharedPrefs.getStringSet(PREFERENCE_PID_SLOW, any()) } returns setOf("3")
+
+        assertEquals(setOf(1L, 2L, 3L), strategy.getPIDs())
+    }
+
+    @Test
+    fun `getPIDs silently drops non-numeric entries from the slow preference`() {
+        every { sharedPrefs.getStringSet(PREFERENCE_PID_FAST, any()) } returns setOf("1")
+        every { sharedPrefs.getStringSet(PREFERENCE_PID_SLOW, any()) } returns setOf("2", "not-a-number")
+
+        assertEquals(setOf(1L, 2L), strategy.getPIDs())
+    }
+
+    @Test(expected = NumberFormatException::class)
+    fun `getPIDs throws for non-numeric entries in the fast preference (current, unguarded behavior)`() {
+        every { sharedPrefs.getStringSet(PREFERENCE_PID_FAST, any()) } returns setOf("not-a-number")
+        every { sharedPrefs.getStringSet(PREFERENCE_PID_SLOW, any()) } returns emptySet()
+
+        strategy.getPIDs()
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/query/TripInfoQueryStrategyTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/query/TripInfoQueryStrategyTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.query
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.graphs.bl.datalogger.Pid
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val TRIP_INFO_QUERY_PREF_KEY = "pref.aa.trip_info.pids.selected"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class TripInfoQueryStrategyTest : TestSetup() {
+
+    private lateinit var strategy: TripInfoQueryStrategy
+
+    @Before
+    override fun setup() {
+        super.setup()
+        strategy = TripInfoQueryStrategy()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `getDefaultPIDs returns the fixed hard-coded set of trip info pids`() {
+        val defaults = strategy.getDefaultPIDs()
+
+        assertEquals(22, defaults.size)
+        assertTrue(defaults.contains(Pid.ENGINE_SPEED_PID_ID.id))
+        assertTrue(defaults.contains(Pid.VEHICLE_SPEED_PID_ID.id))
+        assertTrue(defaults.contains(Pid.GEAR_ENGAGED_PID_ID.id))
+    }
+
+    @Test
+    fun `getPIDs reads the selection from preferences`() {
+        every { sharedPrefs.getStringSet(TRIP_INFO_QUERY_PREF_KEY, any()) } returns setOf("13", "14")
+
+        assertEquals(setOf(13L, 14L), strategy.getPIDs())
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/trip/FileTripRepositoryTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/trip/FileTripRepositoryTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.trip
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.nio.file.Files
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class FileTripRepositoryTest : TestSetup() {
+
+    private lateinit var tripsDir: File
+    private lateinit var repository: FileTripRepository
+
+    @Before
+    override fun setup() {
+        super.setup()
+        tripsDir = Files.createTempDirectory("trips-test").toFile()
+        every { context.getExternalFilesDir(any()) } returns tripsDir
+
+        repository = FileTripRepository(context, parser = TripDescParser(), serializer = TripModelSerializer())
+    }
+
+    @After
+    fun tearDown() {
+        tripsDir.deleteRecursively()
+        unmockkAll()
+    }
+
+    private fun createTripFile(name: String) {
+        File(tripsDir, name).createNewFile()
+    }
+
+    @Test
+    fun `findAllTripsBy returns an empty collection when the trips directory does not exist`() {
+        every { context.getExternalFilesDir(any()) } returns File(tripsDir, "does-not-exist")
+
+        val result = FileTripRepository(context, parser = TripDescParser(), serializer = TripModelSerializer())
+            .findAllTripsBy(filter = "", profile = "profileA")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `findAllTripsBy returns only trips matching the requested profile, sorted by newest first`() {
+        createTripFile("trip-profileA-1700000000-120.jsonl")
+        createTripFile("trip-profileA-1750000000-60.jsonl")
+        createTripFile("trip-profileB-1700000005-30.jsonl")
+
+        val result = repository.findAllTripsBy(filter = "", profile = "profileA")
+
+        assertEquals(
+            listOf("trip-profileA-1750000000-60.jsonl", "trip-profileA-1700000000-120.jsonl"),
+            result.map { it.fileName }
+        )
+    }
+
+    @Test
+    fun `findAllTripsBy excludes files that do not carry the trip prefix`() {
+        createTripFile("trip-profileA-1700000000-120.jsonl")
+        createTripFile("not_a_trip_file.txt")
+
+        val result = repository.findAllTripsBy(filter = "", profile = "profileA")
+
+        assertEquals(listOf("trip-profileA-1700000000-120.jsonl"), result.map { it.fileName })
+    }
+
+    @Test
+    fun `findAllTripsBy excludes file names that do not decode into enough segments`() {
+        createTripFile("trip-profileA-1700000000-120.jsonl")
+        // Only 3 dash-separated segments after stripping the extension: trip, profileA, badname.
+        createTripFile("trip-profileA-badname.jsonl")
+
+        val result = repository.findAllTripsBy(filter = "", profile = "profileA")
+
+        assertEquals(listOf("trip-profileA-1700000000-120.jsonl"), result.map { it.fileName })
+    }
+
+    @Test
+    fun `findAllTripsBy applies a non-empty filter as a filename prefix`() {
+        createTripFile("trip-profileA-1700000000-120.jsonl")
+        createTripFile("trip-profileA-1750000000-60.jsonl")
+
+        val result = repository.findAllTripsBy(filter = "trip-profileA-1750000000", profile = "profileA")
+
+        assertEquals(listOf("trip-profileA-1750000000-60.jsonl"), result.map { it.fileName })
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/trip/TripDescParserTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/trip/TripDescParserTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.trip
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class TripDescParserTest : TestSetup() {
+
+    private lateinit var parser: TripDescParser
+
+    @Before
+    override fun setup() {
+        super.setup()
+        parser = TripDescParser()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `decodeTripName splits prefix, profile, startTime and length`() {
+        val parts = parser.decodeTripName("trip-profile_5-1700000000-120.jsonl")
+
+        assertEquals(listOf("trip", "profile_5", "1700000000", "120"), parts)
+    }
+
+    @Test
+    fun `decodeTripName strips the synced suffix before splitting`() {
+        val parts = parser.decodeTripName("trip-profile_5-1700000000-120.jsonl.synced")
+
+        assertEquals(listOf("trip", "profile_5", "1700000000", "120"), parts)
+    }
+
+    @Test
+    fun `decodeTripName does not throw when there are fewer dash segments`() {
+        val parts = parser.decodeTripName("trip-profile_5")
+
+        assertEquals(listOf("trip", "profile_5"), parts)
+    }
+
+    @Test
+    fun `getTripDesc resolves a known profile label from preferences`() {
+        every { sharedPrefs.getString(eq("pref.profile.names.profile_5"), any()) } returns "Track Car"
+
+        val desc = parser.getTripDesc("trip-profile_5-1700000000-120.jsonl")
+
+        assertEquals("trip-profile_5-1700000000-120.jsonl", desc.fileName)
+        assertEquals("profile_5", desc.profileId)
+        assertEquals("Track Car", desc.profileLabel)
+        assertEquals("1700000000", desc.startTime)
+        assertEquals("120", desc.tripTimeSec)
+        assertFalse(desc.isSynced)
+    }
+
+    @Test
+    fun `getTripDesc falls back to the numbered default label when preference unset`() {
+        // TestSetup's relaxed sharedPrefs returns the default value passed to getString,
+        // matching DefaultProfileService's own "Profile N" fallback.
+        val desc = parser.getTripDesc("trip-profile_9-1700000000-120.jsonl")
+
+        assertEquals("Profile 9", desc.profileLabel)
+    }
+
+    @Test
+    fun `getTripDesc marks synced files and defaults missing startTime and tripTimeSec`() {
+        val synced = parser.getTripDesc("trip-profile_5.jsonl.synced")
+
+        assertTrue(synced.isSynced)
+        assertEquals("", synced.startTime)
+        assertEquals("0", synced.tripTimeSec)
+    }
+
+    @Test
+    fun `getTripDesc resolves Unknown for a profile id outside the known range`() {
+        val desc = parser.getTripDesc("trip-not_a_profile-1700000000-120.jsonl")
+
+        assertEquals("Unknown", desc.profileLabel)
+    }
+
+    @Test
+    fun `getTripDesc throws when the file name has no profile segment`() {
+        // Current behavior: p[1] is accessed unconditionally, so a name without a
+        // dash-separated profile segment throws rather than degrading gracefully.
+        assertThrows(IndexOutOfBoundsException::class.java) {
+            parser.getTripDesc("trip.jsonl")
+        }
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/trip/TripModelSerializerTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/trip/TripModelSerializerTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.trip
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.obd.metrics.transport.message.ConnectorResponseFactory
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val PREF_SAVE_CONNECTOR_RESPONSE = "pref.debug.trip.save.connector_response"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class TripModelSerializerTest : TestSetup() {
+
+    @Before
+    override fun setup() {
+        super.setup()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    private fun metricWithResponse(message: String) =
+        Metric(
+            entry = Entry(x = 1.5f, y = 42f, data = 7L),
+            ts = 123456789L,
+            rawAnswer = ConnectorResponseFactory.wrap(message.toByteArray())
+        )
+
+    @Test
+    fun `serializer includes the raw connector response when the debug preference is enabled`() {
+        every { sharedPrefs.getBoolean(eq(PREF_SAVE_CONNECTOR_RESPONSE), any()) } returns true
+
+        val json = TripModelSerializer().serializer.writeValueAsString(metricWithResponse("some-response"))
+
+        assertTrue(json.contains("some-response"))
+    }
+
+    @Test
+    fun `serializer omits the raw connector response when the debug preference is disabled`() {
+        every { sharedPrefs.getBoolean(eq(PREF_SAVE_CONNECTOR_RESPONSE), any()) } returns false
+
+        val json = TripModelSerializer().serializer.writeValueAsString(metricWithResponse("some-response"))
+
+        assertFalse(json.contains("some-response"))
+    }
+
+    @Test
+    fun `deserializer round-trips entry and timestamp but always yields an empty connector response`() {
+        every { sharedPrefs.getBoolean(eq(PREF_SAVE_CONNECTOR_RESPONSE), any()) } returns true
+
+        val serializer = TripModelSerializer()
+        val original = metricWithResponse("some-response")
+
+        val json = serializer.serializer.writeValueAsString(original)
+        val roundTripped = serializer.deserializer.readValue(json, Metric::class.java)
+
+        // Compare fields individually rather than via Entry.equals(): Jackson deserializes
+        // the "y: Any" property as a Double regardless of the original numeric type, so a
+        // whole-object comparison against the original Float would spuriously fail.
+        assertEquals(original.entry.x, roundTripped.entry.x)
+        assertEquals(original.entry.data, roundTripped.entry.data)
+        assertEquals(original.entry.y.toString().toFloat(), roundTripped.entry.y.toString().toFloat())
+        assertEquals(original.ts, roundTripped.ts)
+        // ConnectorResponseDeserializer always returns the fixed empty response,
+        // regardless of what was serialized - this is the real, current behavior.
+        assertEquals("", roundTripped.rawAnswer.message)
+    }
+}

--- a/datalogger/src/test/java/org/obd/graphs/bl/trip/TripVirtualScreenManagerTest.kt
+++ b/datalogger/src/test/java/org/obd/graphs/bl/trip/TripVirtualScreenManagerTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.trip
+
+import io.mockk.every
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.obd.graphs.bl.TestSetup
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val VIRTUAL_SCREEN_SELECTION = "pref.graph.virtual.selected"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class TripVirtualScreenManagerTest : TestSetup() {
+
+    private lateinit var manager: TripVirtualScreenManager
+
+    @Before
+    override fun setup() {
+        super.setup()
+        manager = TripVirtualScreenManager()
+    }
+
+    @After
+    fun tearDown() = unmockkAll()
+
+    @Test
+    fun `getCurrentScreenId defaults to 1 when no preference is stored`() {
+        assertEquals("1", manager.getCurrentScreenId())
+    }
+
+    @Test
+    fun `getCurrentScreenId reflects the stored preference`() {
+        every { sharedPrefs.getString(eq(VIRTUAL_SCREEN_SELECTION), any()) } returns "3"
+
+        assertEquals("3", manager.getCurrentScreenId())
+    }
+
+    @Test
+    fun `updateScreenId writes the given screen id to preferences`() {
+        manager.updateScreenId("2")
+
+        verify { editor.putString(eq(VIRTUAL_SCREEN_SELECTION), eq("2")) }
+    }
+
+    @Test
+    fun `updateScreenId defaults to persisting the current screen id when none is given`() {
+        every { sharedPrefs.getString(eq(VIRTUAL_SCREEN_SELECTION), any()) } returns "4"
+
+        manager.updateScreenId()
+
+        verify { editor.putString(eq(VIRTUAL_SCREEN_SELECTION), eq("4")) }
+    }
+
+    @Test
+    fun `getVirtualScreenPrefKey is scoped to the current screen id`() {
+        every { sharedPrefs.getString(eq(VIRTUAL_SCREEN_SELECTION), any()) } returns "5"
+
+        assertEquals("pref.graph.pids.selected.5", manager.getVirtualScreenPrefKey())
+    }
+
+    @Test
+    fun `getCurrentMetrics reads from the current screen's preference key`() {
+        every { sharedPrefs.getString(eq(VIRTUAL_SCREEN_SELECTION), any()) } returns "5"
+        every { sharedPrefs.getStringSet(eq("pref.graph.pids.selected.5"), any()) } returns setOf("13", "14")
+
+        assertEquals(setOf("13", "14"), manager.getCurrentMetrics())
+    }
+
+    @Test
+    fun `updateReservedVirtualScreen always writes to the reserved screen key`() {
+        every { sharedPrefs.getString(eq(VIRTUAL_SCREEN_SELECTION), any()) } returns "5"
+
+        manager.updateReservedVirtualScreen(listOf("13", "14"))
+
+        verify { editor.putStringSet(eq("pref.graph.pids.selected.6"), eq(setOf("13", "14"))) }
+    }
+}


### PR DESCRIPTION
Adds 121 new unit tests (InMemoryCarMetricsCollector, MetricsBuilder/Metric, the query-strategy family, ObdMetricExt, PidDefinitionSerializer, AdjustmentsStrategy, VehicleCapabilitiesManager, AutoConnect, ConnectionManager, VehicleStatusMetricsProcessor, MetricsObserver, TripDescParser, TripModelSerializer, TripVirtualScreenManager and FileTripRepository) and wires them into DataLoggerTestSuite, raising module line coverage from effectively untested to 51%.

Also adds a JaCoCo report task to datalogger/build.gradle, including a fix for Robolectric's sandboxed classloader causing the on-the-fly agent to drop most classes as "no location" (includeNoLocationClasses = true).