### PR TITLE
fix(ui): apply dark-mode support to remaining app layouts

### DIFF
--- a/app/src/main/res/layout/activity_gps_status.xml
+++ b/app/src/main/res/layout/activity_gps_status.xml
@@ -2,7 +2,7 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#121212"
+    android:background="?android:attr/colorBackground"
     android:padding="16dp">
 
     <LinearLayout
@@ -14,7 +14,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/gps.title"
-            android:textColor="#FFFFFF"
+            android:textColor="?android:attr/textColorPrimary"
             android:textSize="24sp"
             android:textStyle="bold"
             android:layout_marginBottom="24dp"
@@ -25,14 +25,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/gps.status_label"
-            android:textColor="#AAAAAA"
+            android:textColor="?android:attr/textColorSecondary"
             android:textSize="14sp" />
         <TextView
             android:id="@+id/txt_provider"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/gps.waiting_for_fix"
-            android:textColor="#03DAC5"
+            android:textColor="@color/gps_status_accent"
             android:textSize="20sp"
             android:textStyle="bold"
             android:layout_marginBottom="16dp"/>
@@ -41,14 +41,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/gps.accuracy_label"
-            android:textColor="#AAAAAA"
+            android:textColor="?android:attr/textColorSecondary"
             android:textSize="14sp" />
         <TextView
             android:id="@+id/txt_accuracy"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="--"
-            android:textColor="#FFFFFF"
+            android:textColor="?android:attr/textColorPrimary"
             android:textSize="28sp"
             android:textStyle="bold"
             android:layout_marginBottom="16dp"/>
@@ -68,13 +68,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/gps.latitude"
-                    android:textColor="#AAAAAA"/>
+                    android:textColor="?android:attr/textColorSecondary"/>
                 <TextView
                     android:id="@+id/txt_lat"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="0.0000"
-                    android:textColor="#FFFFFF"
+                    android:textColor="?android:attr/textColorPrimary"
                     android:textSize="18sp"/>
             </LinearLayout>
 
@@ -87,13 +87,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/gps.longitude"
-                    android:textColor="#AAAAAA"/>
+                    android:textColor="?android:attr/textColorSecondary"/>
                 <TextView
                     android:id="@+id/txt_lon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="0.0000"
-                    android:textColor="#FFFFFF"
+                    android:textColor="?android:attr/textColorPrimary"
                     android:textSize="18sp"/>
             </LinearLayout>
         </LinearLayout>
@@ -101,7 +101,7 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="#333333"
+            android:background="@color/divider_color"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp"/>
 
@@ -109,14 +109,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/gps.satellites_label"
-            android:textColor="#AAAAAA"
+            android:textColor="?android:attr/textColorSecondary"
             android:textSize="14sp" />
         <TextView
             android:id="@+id/txt_satellites"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="0 / 0"
-            android:textColor="#FFB74D"
+            android:textColor="@color/gps_status_warning"
             android:textSize="24sp"
             android:layout_marginBottom="16dp"/>
 
@@ -124,7 +124,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/gps.debug_log"
-            android:textColor="#AAAAAA"
+            android:textColor="?android:attr/textColorSecondary"
             android:textSize="14sp"
             android:layout_marginTop="20dp"/>
         <TextView
@@ -132,7 +132,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/gps.initializing"
-            android:textColor="#888888"
+            android:textColor="?android:attr/textColorSecondary"
             android:fontFamily="monospace"
             android:textSize="12sp"
             android:layout_marginTop="8dp"/>

--- a/app/src/main/res/layout/dialog_dtc.xml
+++ b/app/src/main/res/layout/dialog_dtc.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minWidth="350dp"
-    android:background="@color/white">
+    android:background="@color/dialog_card_background">
 
     <TextView
         android:id="@+id/header_code"
@@ -14,7 +14,7 @@
         android:minWidth="80dp"
         android:padding="8dp"
         android:text="@string/pref.dtc.code"
-        android:textColor="@color/gray_dark"
+        android:textColor="?android:attr/textColorPrimary"
         android:textSize="16sp"
         android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
@@ -26,7 +26,7 @@
         android:layout_height="wrap_content"
         android:padding="8dp"
         android:text="@string/pref.dtc.description"
-        android:textColor="@color/gray_dark"
+        android:textColor="?android:attr/textColorPrimary"
         android:textSize="16sp"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
@@ -37,7 +37,7 @@
         android:id="@+id/header_divider"
         android:layout_width="0dp"
         android:layout_height="2dp"
-        android:background="#FF909090"
+        android:background="@color/divider_color"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/header_code" />
@@ -88,7 +88,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginStart="4dp"
-                android:backgroundTint="#D32F2F"
+                android:backgroundTint="@color/cardinal"
                 android:text="@string/dtc.action_clear_codes"
                 android:textColor="@android:color/white"
                 android:textSize="12sp" />

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -21,9 +21,7 @@
             android:id="@+id/custom_dialog_layout_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@android:color/transparent"
-            android:theme="@style/ThemeOverlay.AppCompat.Light"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+            android:background="@android:color/transparent" />
     </com.google.android.material.card.MaterialCardView>
 
     <androidx.recyclerview.widget.RecyclerView
@@ -57,7 +55,7 @@
         android:layout_marginHorizontal="8dp"
         android:layout_marginTop="4dp"
         android:layout_marginBottom="8dp"
-        app:cardBackgroundColor="#F0F2F5"
+        app:cardBackgroundColor="@color/dialog_card_background"
         app:cardCornerRadius="12dp"
         app:cardElevation="8dp">
 

--- a/app/src/main/res/layout/dialog_screen_lock.xml
+++ b/app/src/main/res/layout/dialog_screen_lock.xml
@@ -6,7 +6,7 @@
     android:layout_margin="24dp"
     app:cardCornerRadius="0dp"
     app:cardElevation="8dp"
-    app:cardBackgroundColor="@android:color/white">
+    app:cardBackgroundColor="@color/dialog_card_background">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -29,7 +29,7 @@
             android:layout_marginTop="20dp"
             android:gravity="center"
             android:text="@string/pref.dialog.screen.lock.message"
-            android:textColor="@color/gray_dark"
+            android:textColor="?android:attr/textColorPrimary"
             android:textSize="16sp"
             android:textStyle="bold"
             app:layout_constraintTop_toBottomOf="@+id/dialog_screen_lock_progress"

--- a/app/src/main/res/layout/dialog_trip.xml
+++ b/app/src/main/res/layout/dialog_trip.xml
@@ -5,7 +5,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
-    <TableLayout android:background="@color/white"
+    <TableLayout android:background="@color/dialog_card_background"
         android:id="@+id/tablelayout"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
@@ -24,7 +24,7 @@
                 android:gravity="start"
                 android:paddingStart="4dp"
                 android:paddingEnd="0dp"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="12sp"
                 android:textStyle="bold" />
 
@@ -35,7 +35,7 @@
                 android:paddingStart="4dp"
                 android:paddingEnd="0dp"
                 android:text="@string/trip_vehicle_profile"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="15sp"
                 android:textStyle="bold" />
 
@@ -45,7 +45,7 @@
                 android:gravity="start"
                 android:text="@string/trip_start_date"
                 android:textAllCaps="false"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="15sp"
                 android:textStyle="bold" />
 
@@ -56,7 +56,7 @@
                 android:paddingStart="5dp"
                 android:paddingEnd="0dp"
                 android:text="@string/trip_length"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="15sp"
                 android:textStyle="bold" />
 
@@ -68,7 +68,7 @@
                 android:paddingStart="0dp"
                 android:paddingEnd="1dp"
                 android:text="@string/trip_action"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="15sp"
                 android:textStyle="bold" />
 
@@ -81,7 +81,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="2dip"
                 android:layout_weight="2"
-                android:background="#FF909090"
+                android:background="@color/divider_color"
                 android:padding="2dip" />
         </TableRow>
 

--- a/app/src/main/res/layout/dialog_vehicle_metadata.xml
+++ b/app/src/main/res/layout/dialog_vehicle_metadata.xml
@@ -4,7 +4,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
-    <TableLayout android:background="@color/white"
+    <TableLayout android:background="@color/dialog_card_background"
         android:id="@+id/tablelayout"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
@@ -24,7 +24,7 @@
                 android:paddingStart="4dp"
                 android:paddingEnd="0dp"
                 android:text="@string/pref.vehicle.metadata.name"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="16sp"
                 android:textStyle="bold" />
 
@@ -34,7 +34,7 @@
                 android:gravity="start"
                 android:text="@string/pref.vehicle.metadata.value"
                 android:textAllCaps="false"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="16sp"
                 android:textStyle="bold" />
         </TableRow>
@@ -45,7 +45,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="2dip"
                 android:layout_weight="2"
-                android:background="#FF909090"
+                android:background="@color/divider_color"
                 android:padding="2dip" />
         </TableRow>
 
@@ -56,7 +56,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/tablelayout"
-        android:background="@color/white" />
+        android:background="@color/dialog_card_background" />
 
     <LinearLayout
         android:id="@+id/status_panel"

--- a/app/src/main/res/layout/item_dtc.xml
+++ b/app/src/main/res/layout/item_dtc.xml
@@ -52,14 +52,14 @@
             android:id="@+id/dtc_detail_system_info"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/gray_dark"
+            android:textColor="?android:attr/textColorSecondary"
             android:textSize="13sp" />
 
         <TextView
             android:id="@+id/dtc_detail_hex_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="@color/gray_dark"
+            android:textColor="?android:attr/textColorSecondary"
             android:textSize="13sp"
             android:layout_marginTop="4dp" />
 
@@ -68,7 +68,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:background="#F0F4F8"
+            android:background="@color/surface_variant"
             android:padding="8dp"
             android:orientation="vertical"
             android:visibility="gone">
@@ -86,7 +86,7 @@
                 android:id="@+id/dtc_detail_snapshot_info"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorSecondary"
                 android:textSize="13sp"
                 android:textIsSelectable="true" />
         </LinearLayout>
@@ -112,7 +112,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/dtc.action_copy"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorSecondary"
                 android:textSize="12sp" />
         </LinearLayout>
 
@@ -122,7 +122,7 @@
         android:id="@+id/item_divider"
         android:layout_width="0dp"
         android:layout_height="1dp"
-        android:background="#E0E0E0"
+        android:background="@color/divider_color"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_trip.xml
+++ b/app/src/main/res/layout/item_trip.xml
@@ -9,7 +9,7 @@
         android:id="@+id/tablelayout"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:background="@color/dialog_card_background"
         android:paddingStart="0dp"
         android:paddingEnd="2dip"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -30,7 +30,7 @@
                 android:gravity="start"
                 android:paddingStart="4dp"
                 android:paddingEnd="0dp"
-                android:textColor="@color/gray_dark"
+                android:textColor="?android:attr/textColorPrimary"
                 android:textSize="14sp"
                 android:textStyle="bold" />
 
@@ -105,7 +105,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dip"
                 android:layout_weight="1"
-                android:background="#FF909090"
+                android:background="@color/divider_color"
                 android:padding="2dip" />
         </TableRow>
     </TableLayout>

--- a/app/src/main/res/layout/item_vehicle_metadata.xml
+++ b/app/src/main/res/layout/item_vehicle_metadata.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <TableLayout android:background="@color/white"
+    <TableLayout android:background="@color/dialog_card_background"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -48,7 +48,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="1dip"
                 android:layout_weight="1"
-                android:background="#FF909090"
+                android:background="@color/divider_color"
                 android:padding="2dip" />
         </TableRow>
     </TableLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -10,4 +10,9 @@
 
     <color name="dynamic_selector_sport">#F87171</color>
     <color name="cardinal">#F43F5E</color>
+
+    <color name="divider_color">#3A3A3A</color>
+    <color name="surface_variant">#2A2E33</color>
+    <color name="gps_status_accent">#03DAC5</color>
+    <color name="gps_status_warning">#FFB74D</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -16,4 +16,9 @@
     <color name="beveled_green_shadow">#152B1E</color>
 
     <color name="screen_background">#1C1E20</color>
+
+    <color name="divider_color">#E0E0E0</color>
+    <color name="surface_variant">#E4E7EB</color>
+    <color name="gps_status_accent">#00897B</color>
+    <color name="gps_status_warning">#EF6C00</color>
 </resources>


### PR DESCRIPTION
Several preference dialogs/lists and the GPS status screen never picked up the day/night theme added in #185 - they hardcoded @color/white, raw hex backgrounds, or a fixed dialog_card_background hex value instead of the theme-aware resource, so they stayed light-themed regardless of the app's dark-mode setting.

- activity_gps_status.xml: fully hardcoded hex screen, converted to theme attributes/colors
- dialog_dtc/dialog_trip/dialog_vehicle_metadata/dialog_screen_lock and their item_* list rows: swapped @color/white and raw hex backgrounds for the already day/night-aware @color/dialog_card_background
- dialog_pid.xml: one of its two cards hardcoded the light-mode hex value of dialog_card_background directly instead of referencing it, and its toolbar forced ThemeOverlay.AppCompat.Light regardless of theme
- @color/gray_dark text on now-dark-capable backgrounds had unreadable contrast; swapped to textColorPrimary/textColorSecondary
- added shared divider_color and surface_variant color pairs to replace repeated #FF909090/#E0E0E0/#F0F4F8 hardcodes

Deliberately left the gauge/dashboard/graph rendering surfaces and the main activity's persistent chrome untouched - those are an intentional always-dark instrument-cluster look, not a dark-mode gap.