### PR TITLE
feat(pid-edit): add CAN Network override, required-field validation, 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,10 @@
 # CLAUDE.md (org.obd.graphs)
 
-## 🤖 AI Assistant Directives (Token & Context Optimization)
+## 🤖 AI Assistant Directives (Token & Context Management)
+* **Aggressive Context Management:**
+    * You MUST monitor context size. Prompt the user to use `/compact` mid-task if the conversation history grows too long (to prevent >150k token context bloat and expensive cache reads).
+    * Remind the user to use `/clear` when switching to a completely new task or a different module. Do not carry stale context.
+* **Subagent & Fork Efficiency:** When spawning subagents or using "forks", keep instructions strictly scoped to prevent runaway loops. If performing simple file-system reads, prefer cheaper models (like Haiku) if the environment allows it.
 * **Brevity is required:** Provide code solutions directly. Omit preamble, conversational filler, and lengthy explanations unless explicitly requested.
 * **Progressive Disclosure:** Do not assume the entire architecture up front. If deep context is needed for a specific module (e.g., `:datalogger`), read its local `README.md` before writing code.
 * **Targeted Fixes:** When fixing existing files, output only the modified blocks or reference specific line numbers rather than re-writing the entire file.

--- a/app/src/main/java/org/obd/graphs/preferences/pid/EditPidBottomSheet.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/EditPidBottomSheet.kt
@@ -29,6 +29,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.textfield.TextInputEditText
 import org.obd.graphs.DiagnosticRequestIDManager
 import org.obd.graphs.R
+import org.obd.metrics.api.CANNetwork
 import org.obd.metrics.pid.ValueType
 
 data class PidFormData(
@@ -36,6 +37,7 @@ data class PidFormData(
     val longDescription: String?,
     val mode: String?,
     val canHeader: String?,
+    val canNetwork: CANNetwork?,
     val pidCode: String?,
     val formula: String?,
     val length: Int,
@@ -86,6 +88,10 @@ class EditPidBottomSheet(
         val canHeaders = DiagnosticRequestIDManager.getMappings().map { it.requestKey }
         etCanHeader.setupDropdown(canHeaders, "01")
 
+        val noneCanNetwork = getString(R.string.pref_pid_alert_can_network_none)
+        val etCanNetwork = view.findViewById<AutoCompleteTextView>(R.id.etCanNetwork)
+        etCanNetwork.setupDropdown(listOf(noneCanNetwork) + CANNetwork.values().map { it.name }, noneCanNetwork)
+
         val etValueType = view.findViewById<AutoCompleteTextView>(R.id.etValueType)
         etValueType.setupDropdown(listOf("INT", "DOUBLE", "SHORT"), ValueType.DOUBLE.name)
 
@@ -130,6 +136,7 @@ class EditPidBottomSheet(
 
         if (pidItem != null) {
             etCanHeader.setText(pidItem.source.deductMode(), false)
+            etCanNetwork.setText(pidItem.source.overrides?.canNetwork?.name ?: noneCanNetwork, false)
             etMode.setText(pidItem.source.mode, false)
             etDescription.setText(pidItem.source.description)
             etLongDescription.setText(pidItem.source.longDescription)
@@ -164,6 +171,8 @@ class EditPidBottomSheet(
                 etLongDescription = etLongDescription,
                 etMode = etMode,
                 etCanHeader = etCanHeader,
+                etCanNetwork = etCanNetwork,
+                noneCanNetwork = noneCanNetwork,
                 etPidCode = etPidCode,
                 etFormula = etFormula,
                 etLength = etLength,
@@ -178,7 +187,14 @@ class EditPidBottomSheet(
                 etValueType = etValueType
             )
 
-            if (mode.isEdit && (formData.description.isNullOrEmpty() || formData.mode.isNullOrEmpty() || formData.pidCode.isNullOrEmpty())) {
+            if (mode.isEdit && (
+                    formData.description.isNullOrEmpty() ||
+                        formData.mode.isNullOrEmpty() ||
+                        formData.pidCode.isNullOrEmpty() ||
+                        formData.min == null ||
+                        formData.max == null
+                    )
+            ) {
                 tvError.text = getString(R.string.pref_pid_manage_dialog_validation_required_fields)
                 tvError.visibility = View.VISIBLE
                 return@setOnClickListener
@@ -194,6 +210,8 @@ class EditPidBottomSheet(
         etLongDescription: TextInputEditText,
         etMode: AutoCompleteTextView,
         etCanHeader: AutoCompleteTextView,
+        etCanNetwork: AutoCompleteTextView,
+        noneCanNetwork: String,
         etPidCode: TextInputEditText,
         etFormula: TextInputEditText,
         etLength: AutoCompleteTextView,
@@ -212,6 +230,12 @@ class EditPidBottomSheet(
             longDescription = if (mode.isEdit) etLongDescription.text.toString().trim() else null,
             mode = if (mode.isEdit) etMode.text.toString().trim() else null,
             canHeader = if (mode.isEdit) etCanHeader.text.toString().trim() else null,
+            canNetwork = if (mode.isEdit) {
+                val selected = etCanNetwork.text.toString().trim()
+                if (selected.isEmpty() || selected == noneCanNetwork) null else CANNetwork.valueOf(selected)
+            } else {
+                null
+            },
             pidCode = if (mode.isEdit) etPidCode.text.toString().trim() else null,
             formula = if (mode.isEdit) etFormula.text.toString().trim() else null,
             length = etLength.text.toString().toIntOrNull() ?: 1,

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -120,8 +120,9 @@ open class PidDefinitionDialogFragment(
                     formData.min,
                     formData.max,
                     parsedType,
-                    PidDefinition.Overrides(formData.canHeader, formData.batch, null)
+                    PidDefinition.Overrides(formData.canHeader, formData.batch, formData.canNetwork)
                 ).apply {
+                    group = org.obd.metrics.pid.PIDsGroup.LIVEDATA
                     longDescription = formData.longDescription
                     stable = formData.stable
                     alert.lowerThreshold = formData.lowerThreshold
@@ -147,7 +148,7 @@ open class PidDefinitionDialogFragment(
                     min = formData.min
                     max = formData.max
                     type = parsedType
-                    overrides = PidDefinition.Overrides(formData.canHeader, formData.batch, null)
+                    overrides = PidDefinition.Overrides(formData.canHeader, formData.batch, formData.canNetwork)
                     longDescription = formData.longDescription
                     stable = formData.stable
                     alert.lowerThreshold = formData.lowerThreshold
@@ -233,7 +234,9 @@ open class PidDefinitionDialogFragment(
     }
 
     private fun attachActionButtons() {
-        root.findViewById<Button>(R.id.pid_list_save).setOnClickListener {
+        val btnSave = root.findViewById<Button>(R.id.pid_list_save)
+        btnSave.visibility = if (dialogMode.isInteractive) View.GONE else View.VISIBLE
+        btnSave.setOnClickListener {
             viewModel.persistSelection()
         }
 

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewModel.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewModel.kt
@@ -104,7 +104,11 @@ class PidDefinitionViewModel(
         viewModelScope.launch(Dispatchers.Default) {
             allMasterItems.forEach { it.checked = selectAll }
             val updated = applyFilter(allMasterItems, _uiState.value.searchQuery)
-            _uiState.value = _uiState.value.copy(items = allMasterItems, filteredItems = updated)
+            _uiState.value = _uiState.value.copy(
+                items = ArrayList(allMasterItems),
+                filteredItems = ArrayList(updated),
+                lastUpdate = System.currentTimeMillis()
+            )
         }
     }
 
@@ -308,7 +312,13 @@ class PidDefinitionViewModel(
     }
 
     private fun isSupported(ecuSupportedPIDs: MutableList<String>, p: PidDefinition): Boolean =
-        if (p.mode == "01") ecuSupportedPIDs.contains(p.pid.lowercase()) else true
+        if (p.isUserCustom) {
+            true
+        } else if (p.mode == "01") {
+            ecuSupportedPIDs.contains(p.pid.lowercase())
+        } else {
+            true
+        }
 }
 
 class PidViewModelFactory(

--- a/app/src/main/res/layout/dialog_pid_edit.xml
+++ b/app/src/main/res/layout/dialog_pid_edit.xml
@@ -52,51 +52,74 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:orientation="horizontal">
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="4dp"
+                    android:hint="@string/pref.pid.alert.mode_hint">
+                    <AutoCompleteTextView
+                        android:id="@+id/etMode"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
+                        android:inputType="none" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilCanHeader"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1.5"
+                    android:layout_marginEnd="4dp"
+                    android:hint="@string/pref.pid.manage_dialog.can_header">
+
+                    <AutoCompleteTextView
+                        android:id="@+id/etCanHeader"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/pref.pid.alert.pid_code_hint">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etPidCode"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilCanNetwork"
                 style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginEnd="4dp"
-                android:hint="@string/pref.pid.alert.mode_hint">
+                android:layout_marginTop="12dp"
+                android:hint="@string/pref.pid.alert.can_network_hint">
+
                 <AutoCompleteTextView
-                    android:id="@+id/etMode"
+                    android:id="@+id/etCanNetwork"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:focusable="false"
                     android:focusableInTouchMode="false"
                     android:inputType="none" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/tilCanHeader"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1.5"
-                android:layout_marginEnd="4dp"
-                android:hint="@string/pref.pid.manage_dialog.can_header">
-
-                <AutoCompleteTextView
-                    android:id="@+id/etCanHeader"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:inputType="text" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:hint="@string/pref.pid.alert.pid_code_hint">
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/etPidCode"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:inputType="text" />
             </com.google.android.material.textfield.TextInputLayout>
         </LinearLayout>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -152,7 +152,7 @@
     <string name="pref.pid.manage_dialog.edit_alerts_title">Edytuj alerty</string>
     <string name="pref.pid.manage_dialog.edit_pid_title">Edytuj PID</string>
     <string name="pref.pid.manage_dialog.add_new_pid_title">Dodaj nowy PID</string>
-    <string name="pref.pid.manage_dialog.validation_required_fields">Opis, Tryb i Kod PID są wymagane!</string>
+    <string name="pref.pid.manage_dialog.validation_required_fields">Opis, Tryb, Kod PID, Min i Max są wymagane!</string>
     <string name="pref.pid.manage_dialog.hint_description">Opis (np. Temp. Oleju)</string>
     <string name="pref.pid.manage_dialog.hint_long_description">Długi opis</string>
     <string name="pref.pid.manage_dialog.hint_mode">Tryb (np. 01)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -182,6 +182,8 @@
     <string name="pref.pid.alert.max_hint">Maks</string>
     <string name="pref.pid.alert.units_hint">Jednostki</string>
     <string name="pref.pid.alert.value_type_hint">Typ wartości</string>
+    <string name="pref.pid.alert.can_network_hint">Sieć CAN</string>
+    <string name="pref.pid.alert.can_network_none">Brak</string>
     <string name="pref.pid.alert.stable_text">Stabilny</string>
     <string name="pref.pid.alert.batch_text">Zapytanie grupowe (Batch)</string>
     <string name="pref.pid.alert.cacheable_text">Pamięć podręczna (Cache)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,7 +66,7 @@
     <string name="pref.pid.manage_dialog.edit_alerts_title">Edit Alerts</string>
     <string name="pref.pid.manage_dialog.edit_pid_title">Edit PID</string>
     <string name="pref.pid.manage_dialog.add_new_pid_title">Add New PID</string>
-    <string name="pref.pid.manage_dialog.validation_required_fields">Description, Mode, and PID Code are required!</string>
+    <string name="pref.pid.manage_dialog.validation_required_fields">Description, Mode, PID Code, Min, and Max are required!</string>
     <string name="pref.pid.manage_dialog.hint_description">Description (e.g. Oil Temp)</string>
     <string name="pref.pid.manage_dialog.hint_long_description">Long Description</string>
     <string name="pref.pid.manage_dialog.hint_mode">Mode (e.g. 01)</string>
@@ -99,6 +99,8 @@
     <string name="pref.pid.alert.max_hint">Max</string>
     <string name="pref.pid.alert.units_hint">Units</string>
     <string name="pref.pid.alert.value_type_hint">Value Type</string>
+    <string name="pref.pid.alert.can_network_hint">CAN Network</string>
+    <string name="pref.pid.alert.can_network_none">None</string>
     <string name="pref.pid.alert.stable_text">Stable</string>
     <string name="pref.pid.alert.batch_text">Batch</string>
     <string name="pref.pid.alert.cacheable_text">Cacheable</string>


### PR DESCRIPTION
…and list bug fixes

Add a CAN Network dropdown (MS_CAN/HS_CAN/CH_CAN, defaulting to none) to the PID add/edit dialog, wired into PidDefinition.Overrides. Extend the required-field validation to also cover Min/Max. Fix newly created custom PIDs not appearing in the list (missing group assignment, and ECU-support check incorrectly applied to user-defined PIDs). Fix Select All/Deselect All not refreshing the list due to a StateFlow no-op update. Hide the list Save button in edit/alert mode since those dialogs persist directly.