### PR TITLE
feat(pid-edit): add JavaScript formula validator

### DIFF
--- a/app/src/main/java/org/obd/graphs/preferences/pid/EditPidBottomSheet.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/EditPidBottomSheet.kt
@@ -25,12 +25,18 @@ import android.widget.AutoCompleteTextView
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.TextView
+import androidx.core.widget.doAfterTextChanged
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
 import org.obd.graphs.DiagnosticRequestIDManager
 import org.obd.graphs.R
+import org.obd.graphs.bl.datalogger.JS_ENGINE_NAME
 import org.obd.metrics.api.CANNetwork
 import org.obd.metrics.pid.ValueType
+import javax.script.Compilable
+import javax.script.ScriptEngineManager
+import javax.script.SimpleBindings
 
 data class PidFormData(
     val description: String?,
@@ -75,7 +81,8 @@ class EditPidBottomSheet(
         val tilLongDescription = view.findViewById<View>(R.id.tilLongDescription)
         val llCorePidFields = view.findViewById<View>(R.id.llCorePidFields)
         val llDataFields = view.findViewById<View>(R.id.llDataFields)
-        val tilFormula = view.findViewById<View>(R.id.tilFormula)
+        val tilFormula = view.findViewById<TextInputLayout>(R.id.tilFormula)
+        val tvFormulaRules = view.findViewById<View>(R.id.tvFormulaRules)
         val llToggles = view.findViewById<View>(R.id.llToggles)
 
         val etDescription = view.findViewById<TextInputEditText>(R.id.etDescription)
@@ -101,6 +108,18 @@ class EditPidBottomSheet(
         val etLength = view.findViewById<AutoCompleteTextView>(R.id.etLength)
         etLength.setupDropdown((1..12).map { it.toString() }, "1")
 
+        fun validateFormula() {
+            val length = etLength.text.toString().toIntOrNull() ?: 1
+            tilFormula.error = if (isFormulaValid(etFormula.text.toString(), length)) {
+                null
+            } else {
+                getString(R.string.pref_pid_alert_formula_validation_error)
+            }
+        }
+
+        etFormula.doAfterTextChanged { validateFormula() }
+        etLength.doAfterTextChanged { validateFormula() }
+
         val etMin = view.findViewById<TextInputEditText>(R.id.etMin)
         val etMax = view.findViewById<TextInputEditText>(R.id.etMax)
         val etUnits = view.findViewById<TextInputEditText>(R.id.etUnits)
@@ -120,6 +139,7 @@ class EditPidBottomSheet(
             llCorePidFields.visibility = View.GONE
             llDataFields.visibility = View.GONE
             tilFormula.visibility = View.GONE
+            tvFormulaRules.visibility = View.GONE
             llToggles.visibility = View.GONE
 
             tvTitle.text = pidItem?.source?.description ?: getString(R.string.pref_pid_manage_dialog_edit_alerts_title)
@@ -129,6 +149,7 @@ class EditPidBottomSheet(
             llCorePidFields.visibility = View.VISIBLE
             llDataFields.visibility = View.VISIBLE
             tilFormula.visibility = View.VISIBLE
+            tvFormulaRules.visibility = View.VISIBLE
             llToggles.visibility = View.VISIBLE
 
             tvTitle.text = if (pidItem != null) getString(R.string.pref_pid_manage_dialog_edit_pid_title) else getString(R.string.pref_pid_manage_dialog_add_new_pid_title)
@@ -166,6 +187,14 @@ class EditPidBottomSheet(
                 return@setOnClickListener
             }
 
+            val formulaLength = etLength.text.toString().toIntOrNull() ?: 1
+            if (mode.isEdit && !isFormulaValid(etFormula.text.toString(), formulaLength)) {
+                tilFormula.error = getString(R.string.pref_pid_alert_formula_validation_error)
+                tvError.text = getString(R.string.pref_pid_alert_formula_validation_error)
+                tvError.visibility = View.VISIBLE
+                return@setOnClickListener
+            }
+
             val formData = extractFormData(
                 etDescription = etDescription,
                 etLongDescription = etLongDescription,
@@ -191,6 +220,7 @@ class EditPidBottomSheet(
                     formData.description.isNullOrEmpty() ||
                         formData.mode.isNullOrEmpty() ||
                         formData.pidCode.isNullOrEmpty() ||
+                        formData.formula.isNullOrEmpty() ||
                         formData.min == null ||
                         formData.max == null
                     )
@@ -249,6 +279,22 @@ class EditPidBottomSheet(
             upperThreshold = upperVal,
             valueType = if (mode.isEdit) etValueType.text.toString().trim() else ValueType.DOUBLE.name
         )
+    }
+
+    private fun isFormulaValid(formula: String, length: Int): Boolean {
+        if (formula.isBlank()) return true
+
+        val engine = ScriptEngineManager().getEngineByName(JS_ENGINE_NAME) as? Compilable ?: return true
+        return try {
+            val compiled = engine.compile(formula)
+            val bindings = SimpleBindings()
+            val paramCount = length.coerceIn(1, 26)
+            ('A' until 'A' + paramCount).forEach { bindings[it.toString()] = 0 }
+            compiled.eval(bindings)
+            true
+        } catch (e: Exception) {
+            false
+        }
     }
 
     private fun AutoCompleteTextView.setupDropdown(

--- a/app/src/main/res/layout/dialog_pid_edit.xml
+++ b/app/src/main/res/layout/dialog_pid_edit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:clipToPadding="false"
@@ -33,19 +34,44 @@
                 android:inputType="text" />
         </com.google.android.material.textfield.TextInputLayout>
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilLongDescription"
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:hint="@string/pref.pid.alert.long_description_hint">
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/etLongDescription"
-                android:layout_width="match_parent"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilLongDescription"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:inputType="textMultiLine" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_weight="1"
+                android:layout_marginEnd="4dp"
+                android:hint="@string/pref.pid.alert.long_description_hint">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etLongDescription"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textMultiLine" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilValueType"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/pref.pid.alert.value_type_hint">
+
+                <AutoCompleteTextView
+                    android:id="@+id/etValueType"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:focusable="false"
+                    android:focusableInTouchMode="false"
+                    android:inputType="none" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
 
         <LinearLayout
             android:id="@+id/llCorePidFields"
@@ -80,8 +106,7 @@
                     style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1.5"
-                    android:layout_marginEnd="4dp"
+                    android:layout_weight="1"
                     android:hint="@string/pref.pid.manage_dialog.can_header">
 
                     <AutoCompleteTextView
@@ -90,12 +115,20 @@
                         android:layout_height="wrap_content"
                         android:inputType="text" />
                 </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal">
 
                 <com.google.android.material.textfield.TextInputLayout
                     style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
+                    android:layout_marginEnd="4dp"
                     android:hint="@string/pref.pid.alert.pid_code_hint">
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/etPidCode"
@@ -103,24 +136,24 @@
                         android:layout_height="wrap_content"
                         android:inputType="text" />
                 </com.google.android.material.textfield.TextInputLayout>
-            </LinearLayout>
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/tilCanNetwork"
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="12dp"
-                android:hint="@string/pref.pid.alert.can_network_hint">
-
-                <AutoCompleteTextView
-                    android:id="@+id/etCanNetwork"
-                    android:layout_width="match_parent"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilCanNetwork"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:focusable="false"
-                    android:focusableInTouchMode="false"
-                    android:inputType="none" />
-            </com.google.android.material.textfield.TextInputLayout>
+                    android:layout_weight="1"
+                    android:hint="@string/pref.pid.alert.can_network_hint">
+
+                    <AutoCompleteTextView
+                        android:id="@+id/etCanNetwork"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
+                        android:inputType="none" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
         </LinearLayout>
 
         <LinearLayout
@@ -128,84 +161,79 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
-            <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginEnd="4dp"
-                android:hint="@string/pref.pid.alert.length_hint">
-                <AutoCompleteTextView
-                    android:id="@+id/etLength"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:focusable="false"
-                    android:focusableInTouchMode="false"
-                    android:inputType="none" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginEnd="4dp"
-                android:hint="@string/pref.pid.alert.min_hint">
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/etMin"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:digits="0123456789.-"
-                    android:inputType="numberSigned|numberDecimal" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:layout_marginEnd="4dp"
-                android:hint="@string/pref.pid.alert.max_hint">
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/etMax"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:digits="0123456789.-"
-                    android:inputType="numberSigned|numberDecimal" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <com.google.android.material.textfield.TextInputLayout
-                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:hint="@string/pref.pid.alert.units_hint">
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/etUnits"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:inputType="text" />
-            </com.google.android.material.textfield.TextInputLayout>
-        </LinearLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/tilValueType"
-            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="12dp"
-            android:hint="@string/pref.pid.alert.value_type_hint">
-
-            <AutoCompleteTextView
-                android:id="@+id/etValueType"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:focusable="false"
-                android:focusableInTouchMode="false"
-                android:inputType="none" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:orientation="horizontal">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="4dp"
+                    android:hint="@string/pref.pid.alert.length_hint">
+                    <AutoCompleteTextView
+                        android:id="@+id/etLength"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:focusable="false"
+                        android:focusableInTouchMode="false"
+                        android:inputType="none" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/pref.pid.alert.units_hint">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etUnits"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginEnd="4dp"
+                    android:hint="@string/pref.pid.alert.min_hint">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etMin"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:digits="0123456789.-"
+                        android:inputType="numberSigned|numberDecimal" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/pref.pid.alert.max_hint">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etMax"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:digits="0123456789.-"
+                        android:inputType="numberSigned|numberDecimal" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+        </LinearLayout>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/tilFormula"
@@ -213,13 +241,24 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
-            android:hint="@string/pref.pid.alert.edit_formula_hint">
+            android:hint="@string/pref.pid.alert.edit_formula_hint"
+            app:helperTextEnabled="true"
+            app:helperText="@string/pref.pid.alert.formula_helper_text">
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/etFormula"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:inputType="text" />
         </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
+            android:id="@+id/tvFormulaRules"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/pref.pid.alert.formula_rules"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp" />
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -152,7 +152,7 @@
     <string name="pref.pid.manage_dialog.edit_alerts_title">Edytuj alerty</string>
     <string name="pref.pid.manage_dialog.edit_pid_title">Edytuj PID</string>
     <string name="pref.pid.manage_dialog.add_new_pid_title">Dodaj nowy PID</string>
-    <string name="pref.pid.manage_dialog.validation_required_fields">Opis, Tryb, Kod PID, Min i Max są wymagane!</string>
+    <string name="pref.pid.manage_dialog.validation_required_fields">Opis, Tryb, Kod PID, Formuła, Min i Max są wymagane!</string>
     <string name="pref.pid.manage_dialog.hint_description">Opis (np. Temp. Oleju)</string>
     <string name="pref.pid.manage_dialog.hint_long_description">Długi opis</string>
     <string name="pref.pid.manage_dialog.hint_mode">Tryb (np. 01)</string>
@@ -177,13 +177,16 @@
     <string name="pref.pid.alert.long_description_hint">Pełny opis</string>
     <string name="pref.pid.alert.mode_hint">Tryb (Mode)</string>
     <string name="pref.pid.alert.pid_code_hint">Kod PID</string>
-    <string name="pref.pid.alert.length_hint">Długość</string>
+    <string name="pref.pid.alert.length_hint">Parametry</string>
     <string name="pref.pid.alert.min_hint">Min</string>
     <string name="pref.pid.alert.max_hint">Maks</string>
     <string name="pref.pid.alert.units_hint">Jednostki</string>
     <string name="pref.pid.alert.value_type_hint">Typ wartości</string>
     <string name="pref.pid.alert.can_network_hint">Sieć CAN</string>
     <string name="pref.pid.alert.can_network_none">Brak</string>
+    <string name="pref.pid.alert.formula_validation_error">Formuła zawiera nieprawidłową składnię JavaScript.</string>
+    <string name="pref.pid.alert.formula_helper_text">np. A + B</string>
+    <string name="pref.pid.alert.formula_rules">Formuła to JavaScript. Parametry określają liczbę dostępnych bajtów odpowiedzi, przypisanych do liter zaczynając od A (Parametry=1 → A, Parametry=2 → A,B, Parametry=3 → A,B,C, itd.). Formuła musi zwracać liczbę.</string>
     <string name="pref.pid.alert.stable_text">Stabilny</string>
     <string name="pref.pid.alert.batch_text">Zapytanie grupowe (Batch)</string>
     <string name="pref.pid.alert.cacheable_text">Pamięć podręczna (Cache)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,7 +66,7 @@
     <string name="pref.pid.manage_dialog.edit_alerts_title">Edit Alerts</string>
     <string name="pref.pid.manage_dialog.edit_pid_title">Edit PID</string>
     <string name="pref.pid.manage_dialog.add_new_pid_title">Add New PID</string>
-    <string name="pref.pid.manage_dialog.validation_required_fields">Description, Mode, PID Code, Min, and Max are required!</string>
+    <string name="pref.pid.manage_dialog.validation_required_fields">Description, Mode, PID Code, Formula, Min, and Max are required!</string>
     <string name="pref.pid.manage_dialog.hint_description">Description (e.g. Oil Temp)</string>
     <string name="pref.pid.manage_dialog.hint_long_description">Long Description</string>
     <string name="pref.pid.manage_dialog.hint_mode">Mode (e.g. 01)</string>
@@ -94,13 +94,16 @@
     <string name="pref.pid.alert.long_description_hint">Long Description</string>
     <string name="pref.pid.alert.mode_hint">Mode</string>
     <string name="pref.pid.alert.pid_code_hint">PID Code</string>
-    <string name="pref.pid.alert.length_hint">Length</string>
+    <string name="pref.pid.alert.length_hint">Parameters</string>
     <string name="pref.pid.alert.min_hint">Min</string>
     <string name="pref.pid.alert.max_hint">Max</string>
     <string name="pref.pid.alert.units_hint">Units</string>
     <string name="pref.pid.alert.value_type_hint">Value Type</string>
     <string name="pref.pid.alert.can_network_hint">CAN Network</string>
     <string name="pref.pid.alert.can_network_none">None</string>
+    <string name="pref.pid.alert.formula_validation_error">Formula contains invalid JavaScript syntax.</string>
+    <string name="pref.pid.alert.formula_helper_text">e.g. A + B</string>
+    <string name="pref.pid.alert.formula_rules">Formula is JavaScript. Parameters sets how many response bytes are available, bound to letters starting at A (Parameters=1 → A, Parameters=2 → A,B, Parameters=3 → A,B,C, and so on). The formula must return a number.</string>
     <string name="pref.pid.alert.stable_text">Stable</string>
     <string name="pref.pid.alert.batch_text">Batch</string>
     <string name="pref.pid.alert.cacheable_text">Cacheable</string>


### PR DESCRIPTION
Validate the formula field by actually compiling and evaluating it with the same JS engine used at runtime (rhino), binding dummy values only for the letters (A, B, C...) that the configured Parameters count would provide - catching both syntax errors and out-of-range parameter references. Formula is now a required field. Add an inline explanation of how Parameters maps to formula variables, and rename the "Length" field to "Parameters" to better reflect its meaning.

Also regroup the add/edit PID dialog fields into clearer paired rows: Mode+CAN Header, PID Code+CAN Network, Long Description+Value Type, and Parameters+Units / Min+Max.