### PR TITLE
fix(pid-edit): resolve top-content scroll glitch in PID edit sheet

### DIFF
--- a/app/src/main/res/layout/dialog_pid_edit.xml
+++ b/app/src/main/res/layout/dialog_pid_edit.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:clipToPadding="false"
     android:fillViewport="true"
     android:paddingBottom="32dp">
@@ -343,4 +343,4 @@
             android:text="@string/pref.pid.alert.edit_save" />
 
     </LinearLayout>
-</ScrollView>
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Plain android.widget.ScrollView doesn't implement NestedScrollingChild, so it fights with BottomSheetBehavior's nested scrolling when reversing scroll direction, causing the top content to clip/disappear. Switch to androidx.core.widget.NestedScrollView, and drop the redundant match_parent height on the root scroll container.