### PR TITLE
feat(adapter): auto-apply required settings for VGate vLinker MS

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ android {
             resValue "string", "DEFAULT_PROFILE", "profile_8"
             resValue "string", "applicationId", "org.obd.graphs.my.giulia.aa"
             applicationId "org.obd.graphs.my.giulia.aa"
-            versionCode 228
+            versionCode 233
         }
 
         giuliaPerformanceMonitor {
@@ -89,7 +89,7 @@ android {
             resValue "string", "DEFAULT_PROFILE", "profile_8"
             resValue "string", "applicationId", "org.obd.graphs.my.giulia.performance_monitor"
             applicationId "org.obd.graphs.my.giulia.performance_monitor"
-            versionCode 106
+            versionCode 110
         }
 
         giulia {

--- a/app/src/main/java/org/obd/graphs/preferences/AdapterTypeListPreference.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/AdapterTypeListPreference.kt
@@ -23,12 +23,17 @@ import androidx.preference.ListPreference
 import org.obd.graphs.DiagnosticMappingItem
 import org.obd.graphs.DiagnosticRequestIDManager
 import org.obd.graphs.R
+import org.obd.graphs.profile.profile
 
 private const val ADAPTER_TYPE_VGATE_VLINKER_MS = "VGATE_VLINKER_MS"
 
 private const val PREF_CONTINUE_ON_ERROR = "pref.adapter.error.continue_on_error"
 private const val PREF_INIT_PROTOCOL = "pref.adapter.init.protocol"
 private const val PREF_INIT_SEQUENCE = "pref.adapter.init.sequence"
+
+private const val PREF_CONTINUE_ON_ERROR_FALLBACK = false
+private const val PREF_INIT_PROTOCOL_FALLBACK = "AUTO"
+private const val PREF_INIT_SEQUENCE_FALLBACK = "DEFAULT"
 
 private const val TRW_CLIMATE_CONTROL_MODE_INDEX = 11
 private const val TRW_CLIMATE_CONTROL_ID = "TRW_CLIMATE_CONTROL"
@@ -40,28 +45,47 @@ class AdapterTypeListPreference(
 ) : ListPreference(context, attrs) {
     init {
         setOnPreferenceChangeListener { _, newValue ->
+            val previousValue = value
+
             if (newValue == ADAPTER_TYPE_VGATE_VLINKER_MS) {
-                Prefs.updateBoolean(PREF_CONTINUE_ON_ERROR, true)
-                Prefs.updateString(PREF_INIT_PROTOCOL, "CAN_USER1")
-                Prefs.updateString(PREF_INIT_SEQUENCE, "HS_CAN")
-
-                DiagnosticRequestIDManager.saveMapping(
-                    DiagnosticMappingItem(
-                        modeIndex = TRW_CLIMATE_CONTROL_MODE_INDEX,
-                        requestKey = TRW_CLIMATE_CONTROL_ID,
-                        headerValue = TRW_CLIMATE_CONTROL_HEADER
-                    )
-                )
-
-                AlertDialog
-                    .Builder(context)
-                    .setTitle(context.getString(R.string.pref_adapter_type_vlinker_ms_dialog_title))
-                    .setMessage(context.getString(R.string.pref_adapter_type_vlinker_ms_dialog_message))
-                    .setCancelable(true)
-                    .setPositiveButton(context.getString(android.R.string.ok), null)
-                    .show()
+                applyVLinkerMsSettings()
+            } else if (previousValue == ADAPTER_TYPE_VGATE_VLINKER_MS) {
+                revertVLinkerMsSettings()
             }
             true
         }
+    }
+
+    private fun applyVLinkerMsSettings() {
+        Prefs.updateBoolean(PREF_CONTINUE_ON_ERROR, true)
+        Prefs.updateString(PREF_INIT_PROTOCOL, "CAN_USER1")
+        Prefs.updateString(PREF_INIT_SEQUENCE, "HS_CAN")
+
+        DiagnosticRequestIDManager.saveMapping(
+            DiagnosticMappingItem(
+                modeIndex = TRW_CLIMATE_CONTROL_MODE_INDEX,
+                requestKey = TRW_CLIMATE_CONTROL_ID,
+                headerValue = TRW_CLIMATE_CONTROL_HEADER
+            )
+        )
+
+        AlertDialog
+            .Builder(context)
+            .setTitle(context.getString(R.string.pref_adapter_type_vlinker_ms_dialog_title))
+            .setMessage(context.getString(R.string.pref_adapter_type_vlinker_ms_dialog_message))
+            .setCancelable(true)
+            .setPositiveButton(context.getString(android.R.string.ok), null)
+            .show()
+    }
+
+    private fun revertVLinkerMsSettings() {
+        Prefs.updateBoolean(PREF_CONTINUE_ON_ERROR, profile.getProfileValue(PREF_CONTINUE_ON_ERROR, PREF_CONTINUE_ON_ERROR_FALLBACK))
+        Prefs.updateString(PREF_INIT_PROTOCOL, profile.getProfileValue(PREF_INIT_PROTOCOL, PREF_INIT_PROTOCOL_FALLBACK))
+        Prefs.updateString(PREF_INIT_SEQUENCE, profile.getProfileValue(PREF_INIT_SEQUENCE, PREF_INIT_SEQUENCE_FALLBACK))
+
+        DiagnosticRequestIDManager.getMappings()
+            .firstOrNull { it.modeIndex == TRW_CLIMATE_CONTROL_MODE_INDEX }
+            ?.takeIf { it.requestKey == TRW_CLIMATE_CONTROL_ID && it.headerValue == TRW_CLIMATE_CONTROL_HEADER }
+            ?.let { DiagnosticRequestIDManager.deleteMapping(it) }
     }
 }

--- a/app/src/main/java/org/obd/graphs/preferences/AdapterTypeListPreference.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/AdapterTypeListPreference.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
+import org.obd.graphs.DiagnosticMappingItem
+import org.obd.graphs.DiagnosticRequestIDManager
 import org.obd.graphs.R
 
 private const val ADAPTER_TYPE_VGATE_VLINKER_MS = "VGATE_VLINKER_MS"
@@ -27,6 +29,10 @@ private const val ADAPTER_TYPE_VGATE_VLINKER_MS = "VGATE_VLINKER_MS"
 private const val PREF_CONTINUE_ON_ERROR = "pref.adapter.error.continue_on_error"
 private const val PREF_INIT_PROTOCOL = "pref.adapter.init.protocol"
 private const val PREF_INIT_SEQUENCE = "pref.adapter.init.sequence"
+
+private const val TRW_CLIMATE_CONTROL_MODE_INDEX = 11
+private const val TRW_CLIMATE_CONTROL_ID = "TRW_CLIMATE_CONTROL"
+private const val TRW_CLIMATE_CONTROL_HEADER = "18DA98F1"
 
 class AdapterTypeListPreference(
     context: Context,
@@ -38,6 +44,14 @@ class AdapterTypeListPreference(
                 Prefs.updateBoolean(PREF_CONTINUE_ON_ERROR, true)
                 Prefs.updateString(PREF_INIT_PROTOCOL, "CAN_USER1")
                 Prefs.updateString(PREF_INIT_SEQUENCE, "HS_CAN")
+
+                DiagnosticRequestIDManager.saveMapping(
+                    DiagnosticMappingItem(
+                        modeIndex = TRW_CLIMATE_CONTROL_MODE_INDEX,
+                        requestKey = TRW_CLIMATE_CONTROL_ID,
+                        headerValue = TRW_CLIMATE_CONTROL_HEADER
+                    )
+                )
 
                 AlertDialog
                     .Builder(context)

--- a/app/src/main/java/org/obd/graphs/preferences/AdapterTypeListPreference.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/AdapterTypeListPreference.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.app.AlertDialog
+import androidx.preference.ListPreference
+import org.obd.graphs.R
+
+private const val ADAPTER_TYPE_VGATE_VLINKER_MS = "VGATE_VLINKER_MS"
+
+private const val PREF_CONTINUE_ON_ERROR = "pref.adapter.error.continue_on_error"
+private const val PREF_INIT_PROTOCOL = "pref.adapter.init.protocol"
+private const val PREF_INIT_SEQUENCE = "pref.adapter.init.sequence"
+
+class AdapterTypeListPreference(
+    context: Context,
+    attrs: AttributeSet?
+) : ListPreference(context, attrs) {
+    init {
+        setOnPreferenceChangeListener { _, newValue ->
+            if (newValue == ADAPTER_TYPE_VGATE_VLINKER_MS) {
+                Prefs.updateBoolean(PREF_CONTINUE_ON_ERROR, true)
+                Prefs.updateString(PREF_INIT_PROTOCOL, "CAN_USER1")
+                Prefs.updateString(PREF_INIT_SEQUENCE, "HS_CAN")
+
+                AlertDialog
+                    .Builder(context)
+                    .setTitle(context.getString(R.string.pref_adapter_type_vlinker_ms_dialog_title))
+                    .setMessage(context.getString(R.string.pref_adapter_type_vlinker_ms_dialog_message))
+                    .setCancelable(true)
+                    .setPositiveButton(context.getString(android.R.string.ok), null)
+                    .show()
+            }
+            true
+        }
+    }
+}

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -108,6 +108,8 @@
     <string name="pref.connection.connection_type"><b><font color='#01804F'>Typ połączenia adaptera OBD</font></b></string>
     <string name="pref.connection.connection_timeout">Limit czasu połączenia</string>
     <string name="pref.adapter.type">Typ adaptera</string>
+    <string name="pref_adapter_type_vlinker_ms_dialog_title">Zastosowano dodatkowe ustawienia</string>
+    <string name="pref_adapter_type_vlinker_ms_dialog_message">VGate vLinker MS wymaga dodatkowych ustawień adaptera. Zostały one zastosowane automatycznie:\n\n• Kontynuuj przy błędach: Włączone\n• Protokół: CAN_USER1\n• Sekwencja inicjalizacyjna: HS_CAN</string>
 
     <string name="pref.adapter.error.continue_on_error">Ignoruj błedy</string>
     <string name="pref.adapter.error.continue_on_error_summary">Nie przerywaj komunikacji z adapterem podczas błędów</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -109,7 +109,7 @@
     <string name="pref.connection.connection_timeout">Limit czasu połączenia</string>
     <string name="pref.adapter.type">Typ adaptera</string>
     <string name="pref_adapter_type_vlinker_ms_dialog_title">Zastosowano dodatkowe ustawienia</string>
-    <string name="pref_adapter_type_vlinker_ms_dialog_message">VGate vLinker MS wymaga dodatkowych ustawień adaptera. Zostały one zastosowane automatycznie:\n\n• Kontynuuj przy błędach: Włączone\n• Protokół: CAN_USER1\n• Sekwencja inicjalizacyjna: HS_CAN</string>
+    <string name="pref_adapter_type_vlinker_ms_dialog_message">VGate vLinker MS wymaga dodatkowych ustawień adaptera. Zostały one zastosowane automatycznie:\n\n• Kontynuuj przy błędach: Włączone\n• Protokół: CAN_USER1\n• Sekwencja inicjalizacyjna: HS_CAN\n• Mapowanie nagłówka CAN: TRW_CLIMATE_CONTROL (18DA98F1)</string>
 
     <string name="pref.adapter.error.continue_on_error">Ignoruj błedy</string>
     <string name="pref.adapter.error.continue_on_error_summary">Nie przerywaj komunikacji z adapterem podczas błędów</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -392,7 +392,7 @@
     <string name="pref.adapter_init_sequence">Init Sequence</string>
     <string name="pref.adapter.type">Adapter Type</string>
     <string name="pref_adapter_type_vlinker_ms_dialog_title">Additional settings applied</string>
-    <string name="pref_adapter_type_vlinker_ms_dialog_message">VGate vLinker MS requires additional adapter settings. These have been applied automatically:\n\n• Continue on errors: Enabled\n• Protocol: CAN_USER1\n• Init Sequence: HS_CAN</string>
+    <string name="pref_adapter_type_vlinker_ms_dialog_message">VGate vLinker MS requires additional adapter settings. These have been applied automatically:\n\n• Continue on errors: Enabled\n• Protocol: CAN_USER1\n• Init Sequence: HS_CAN\n• CAN Header Mapping: TRW_CLIMATE_CONTROL (18DA98F1)</string>
 
     <string name="pref.general_settings">General settings</string>
     <string name="pref.adapter.general_settings">Advanced settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,6 +391,8 @@
     <string name="pref.adapter_init_protocol">Protocol</string>
     <string name="pref.adapter_init_sequence">Init Sequence</string>
     <string name="pref.adapter.type">Adapter Type</string>
+    <string name="pref_adapter_type_vlinker_ms_dialog_title">Additional settings applied</string>
+    <string name="pref_adapter_type_vlinker_ms_dialog_message">VGate vLinker MS requires additional adapter settings. These have been applied automatically:\n\n• Continue on errors: Enabled\n• Protocol: CAN_USER1\n• Init Sequence: HS_CAN</string>
 
     <string name="pref.general_settings">General settings</string>
     <string name="pref.adapter.general_settings">Advanced settings</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -163,7 +163,7 @@
                     app:singleLineTitle="false"
                     app:title="@string/pref.connection.category">
 
-                    <ListPreference
+                    <org.obd.graphs.preferences.AdapterTypeListPreference
                         android:defaultValue="DEFAULT"
                         android:entries="@array/pref.adapter_type_entries"
                         android:entryValues="@array/pref.adapter_type_values"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url 'https://central.sonatype.com/repository/maven-snapshots' }
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         maven { url 'https://jitpack.io' }
      }
 }

--- a/profile/src/main/java/org/obd/graphs/profile/DefaultProfileService.kt
+++ b/profile/src/main/java/org/obd/graphs/profile/DefaultProfileService.kt
@@ -80,6 +80,33 @@ internal class DefaultProfileService :
 
     override fun getCurrentProfileName(): String = Prefs.getS("$PROFILE_NAME_PREFIX.${getCurrentProfile()}", "")
 
+    // Reads straight from the bundled .properties assets, bypassing Prefs, since saveCurrentProfile()
+    // mirrors live (possibly overridden) values back into "<profileId>.<key>" Prefs entries.
+    override fun getProfileDefaultValue(
+        profileId: String,
+        key: String
+    ): String? {
+        val fullKey = "$profileId.$key"
+        return findProfileFiles()
+            ?.firstNotNullOfOrNull { fileName ->
+                runCatching { loadFile(fileName).getProperty(fullKey) }.getOrNull()
+            }
+    }
+
+    // Not every profile overrides every key, so fall back to the default profile before the caller's literal.
+    override fun getProfileValue(
+        key: String,
+        fallback: String
+    ): String =
+        getProfileDefaultValue(getCurrentProfile(), key)
+            ?: getProfileDefaultValue(getDefaultProfile(), key)
+            ?: fallback
+
+    override fun getProfileValue(
+        key: String,
+        fallback: Boolean
+    ): Boolean = getProfileValue(key, fallback.toString()).toBoolean()
+
     override fun restoreBackup() {
         restoreBackup(getBackupFile())
     }

--- a/profile/src/main/java/org/obd/graphs/profile/Profile.kt
+++ b/profile/src/main/java/org/obd/graphs/profile/Profile.kt
@@ -40,6 +40,12 @@ interface Profile {
 
     fun getCurrentProfileName(): String
 
+    fun getProfileDefaultValue(profileId: String, key: String): String?
+
+    fun getProfileValue(key: String, fallback: String): String
+
+    fun getProfileValue(key: String, fallback: Boolean): Boolean
+
     fun reset()
 
     fun init(


### PR DESCRIPTION
Selecting VGATE_VLINKER_MS as the adapter type now automatically sets continue-on-error, init protocol (CAN_USER1), and init sequence (HS_CAN), since this adapter requires them to work correctly. Informs the user via a dialog listing what was applied.