### PR TITLE
feat(wizard): add first-run setup wizard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ android {
             resValue "string", "DEFAULT_PROFILE", "profile_8"
             resValue "string", "applicationId", "org.obd.graphs.my.giulia.aa"
             applicationId "org.obd.graphs.my.giulia.aa"
-            versionCode 233
+            versionCode 234
         }
 
         giuliaPerformanceMonitor {
@@ -89,7 +89,7 @@ android {
             resValue "string", "DEFAULT_PROFILE", "profile_8"
             resValue "string", "applicationId", "org.obd.graphs.my.giulia.performance_monitor"
             applicationId "org.obd.graphs.my.giulia.performance_monitor"
-            versionCode 110
+            versionCode 112
         }
 
         giulia {
@@ -97,7 +97,7 @@ android {
             resValue "string", "DEFAULT_PROFILE", "profile_3"
             resValue "string", "applicationId", "org.obd.graphs.my.giulia"
             applicationId "org.obd.graphs.my.giulia"
-            versionCode 76
+            versionCode 78
         }
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,6 +106,14 @@
         </activity>
 
         <activity
+            android:name="org.obd.graphs.wizard.SetupWizardActivity"
+            android:label="@string/wizard_title"
+            android:exported="false"
+            android:parentActivityName="org.obd.graphs.activity.MainActivity"
+            android:theme="@style/Theme.DefaultTheme">
+        </activity>
+
+        <activity
             android:name="org.obd.graphs.activity.MainActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.App.Starting"

--- a/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
+++ b/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
@@ -60,6 +60,8 @@ import org.obd.graphs.ui.BackupManager
 import org.obd.graphs.ui.CustomPidsBackupManager
 import org.obd.graphs.ui.common.COLOR_PHILIPPINE_GREEN
 import org.obd.graphs.ui.withDataLogger
+import org.obd.graphs.wizard.SetupWizardActivity
+import org.obd.graphs.wizard.SetupWizardManager
 import pub.devrel.easypermissions.AppSettingsDialog
 import pub.devrel.easypermissions.EasyPermissions
 
@@ -182,6 +184,12 @@ class MainActivity :
         super.onResume()
         screen.setupWindowManager(this)
         screen.changeScreenBrightness(this, 1f)
+
+        // Language may have been changed by the setup wizard while this Activity was paused underneath it.
+        val storedLanguage = LanguageManager.getStoredLanguage(this)
+        if (storedLanguage.isNotEmpty() && resources.configuration.locales[0].language != storedLanguage) {
+            recreate()
+        }
     }
 
     override fun onPause() {
@@ -298,7 +306,8 @@ class MainActivity :
     }
 
     private fun runWizardFlow() {
-        if (!LanguageManager.isLanguageSelected(this)) {
+        // Fresh installs pick a language as the wizard's first step instead - asking here too would be redundant.
+        if (!LanguageManager.isLanguageSelected(this) && !SetupWizardManager.shouldShowWizard(this)) {
             LanguageManager.showLanguageSelectionDialog(this) { localeTag ->
                 DataLoggerRepository.updateTranslations(localeTag)
                 recreate()
@@ -306,9 +315,15 @@ class MainActivity :
             return
         }
 
-        if (Permissions.isAnyPermissionMissing(this)) {
+        // Fresh installs grant permissions as a wizard step instead - asking here too would be redundant.
+        if (Permissions.isAnyPermissionMissing(this) && !SetupWizardManager.shouldShowWizard(this)) {
             Permissions.showPermissionOnboarding(this, onDeclined = {
             })
+            return
+        }
+
+        if (SetupWizardManager.shouldShowWizard(this)) {
+            startActivity(Intent(this, SetupWizardActivity::class.java))
             return
         }
     }

--- a/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
+++ b/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
@@ -56,6 +56,7 @@ import org.obd.graphs.preferences.setPreferencesContext
 import org.obd.graphs.profile.profile
 import org.obd.graphs.sendBroadcastEvent
 import org.obd.graphs.setActivityContext
+import org.obd.graphs.theme.ThemeManager
 import org.obd.graphs.ui.BackupManager
 import org.obd.graphs.ui.CustomPidsBackupManager
 import org.obd.graphs.ui.common.COLOR_PHILIPPINE_GREEN
@@ -103,6 +104,7 @@ class MainActivity :
         setupStrictMode()
         setActivityContext(this)
         setPreferencesContext(this)
+        ThemeManager.applyStoredTheme(this)
 
         val splashScreen = installSplashScreen()
 

--- a/app/src/main/java/org/obd/graphs/preferences/ThemeListPreference.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/ThemeListPreference.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.ListPreference
+import org.obd.graphs.theme.ThemeManager
+
+// persistent="false" in the XML: theme is stored in ThemeManager's own SharedPreferences file (mirroring
+// LanguagePreferences/LanguageManager), not the main Prefs, so the ListPreference's displayed value must
+// be synced from there manually rather than relying on the framework's default persistence.
+class ThemeListPreference(
+    context: Context,
+    attrs: AttributeSet?
+) : ListPreference(context, attrs) {
+    init {
+        value = ThemeManager.getStoredTheme(context)
+
+        setOnPreferenceChangeListener { _, newValue ->
+            ThemeManager.saveTheme(context, newValue as String)
+            true
+        }
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/AdapterStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/AdapterStepFragment.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.os.Bundle
+import androidx.preference.PreferenceFragmentCompat
+import org.obd.graphs.R
+
+class AdapterStepFragment : PreferenceFragmentCompat() {
+    override fun onCreatePreferences(
+        savedInstanceState: Bundle?,
+        rootKey: String?
+    ) {
+        setPreferencesFromResource(R.xml.preferences, "pref.adapter.connection")
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/AdapterStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/AdapterStepFragment.kt
@@ -17,8 +17,15 @@
 package org.obd.graphs.wizard
 
 import android.os.Bundle
+import androidx.preference.ListPreference
+import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import org.obd.graphs.R
+import org.obd.graphs.preferences.PREFERENCE_CONNECTION_TYPE
+import org.obd.graphs.preferences.PREFS_CONNECTION_TYPE_CHANGED_EVENT
+import org.obd.graphs.preferences.Prefs
+import org.obd.graphs.preferences.getString
+import org.obd.graphs.sendBroadcastEvent
 
 class AdapterStepFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(
@@ -26,5 +33,31 @@ class AdapterStepFragment : PreferenceFragmentCompat() {
         rootKey: String?
     ) {
         setPreferencesFromResource(R.xml.preferences, "pref.adapter.connection")
+        registerConnectionTypeListener()
+    }
+
+    // Mirrors PreferencesFragment.registerConnectionTypeListener() - narrows the visible
+    // sub-category to the currently selected connection type, since setPreferencesFromResource()
+    // only inflates the XML subtree and doesn't carry over that fragment-specific behavior.
+    private fun registerConnectionTypeListener() {
+        val connectionType = findPreference<ListPreference>(PREFERENCE_CONNECTION_TYPE)
+        val bluetoothCategory = findPreference<Preference>("$PREFERENCE_CONNECTION_TYPE.bluetooth")
+        val wifiCategory = findPreference<Preference>("$PREFERENCE_CONNECTION_TYPE.wifi")
+        val usbCategory = findPreference<Preference>("$PREFERENCE_CONNECTION_TYPE.usb")
+
+        fun applyVisibility(type: String?) {
+            bluetoothCategory?.isVisible = type == "bluetooth"
+            wifiCategory?.isVisible = type == "wifi"
+            usbCategory?.isVisible = type == "usb"
+        }
+
+        applyVisibility(Prefs.getString(PREFERENCE_CONNECTION_TYPE))
+
+        connectionType?.onPreferenceChangeListener =
+            Preference.OnPreferenceChangeListener { _, newValue ->
+                sendBroadcastEvent(PREFS_CONNECTION_TYPE_CHANGED_EVENT)
+                applyVisibility(newValue as? String)
+                true
+            }
     }
 }

--- a/app/src/main/java/org/obd/graphs/wizard/GoogleDriveStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/GoogleDriveStepFragment.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.button.MaterialButton
+import kotlinx.coroutines.launch
+import org.obd.graphs.R
+import org.obd.graphs.integrations.gcp.gdrive.TripLogDriveManager
+
+class GoogleDriveStepFragment : Fragment(R.layout.fragment_wizard_gdrive) {
+    // Constructed in onCreate(), not on click: AuthorizationManager registers an
+    // ActivityResultLauncher in its constructor, which Android requires to happen
+    // before the fragment reaches STARTED - doing it lazily on click throws.
+    private lateinit var driveManager: TripLogDriveManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        driveManager =
+            TripLogDriveManager.instance(
+                getString(R.string.ANDROID_WEB_CLIENT_ID),
+                requireActivity(),
+                this
+            )
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val btnConnect = view.findViewById<MaterialButton>(R.id.btnWizardConnectDrive)
+        btnConnect.setOnClickListener {
+            btnConnect.isEnabled = false
+
+            viewLifecycleOwner.lifecycleScope.launch {
+                driveManager.authenticate()
+                btnConnect.isEnabled = true
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/LanguageStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/LanguageStepFragment.kt
@@ -22,6 +22,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.obd.graphs.R
+import org.obd.graphs.bl.datalogger.DataLoggerRepository
 import org.obd.graphs.language.LanguageAdapter
 import org.obd.graphs.language.LanguageManager
 
@@ -42,7 +43,9 @@ class LanguageStepFragment : Fragment(R.layout.fragment_wizard_language) {
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter =
             LanguageAdapter(names, selectedIndex) { index ->
-                LanguageManager.saveLanguage(requireContext(), codes[index])
+                val localeTag = codes[index]
+                LanguageManager.saveLanguage(requireContext(), localeTag)
+                DataLoggerRepository.updateTranslations(localeTag)
                 requireActivity().recreate()
             }
     }

--- a/app/src/main/java/org/obd/graphs/wizard/LanguageStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/LanguageStepFragment.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import org.obd.graphs.R
+import org.obd.graphs.language.LanguageAdapter
+import org.obd.graphs.language.LanguageManager
+
+class LanguageStepFragment : Fragment(R.layout.fragment_wizard_language) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val names = resources.getStringArray(org.obd.graphs.commons.R.array.language_names)
+        val codes = resources.getStringArray(org.obd.graphs.commons.R.array.language_codes)
+
+        val currentLangCode = LanguageManager.getStoredLanguage(requireContext())
+        val selectedIndex = codes.indexOf(currentLangCode).takeIf { it >= 0 } ?: -1
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.rvWizardLanguages)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter =
+            LanguageAdapter(names, selectedIndex) { index ->
+                LanguageManager.saveLanguage(requireContext(), codes[index])
+                requireActivity().recreate()
+            }
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/PermissionsStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/PermissionsStepFragment.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.google.android.material.button.MaterialButton
+import org.obd.graphs.Permissions
+import org.obd.graphs.R
+
+class PermissionsStepFragment : Fragment(R.layout.fragment_wizard_permissions) {
+    private lateinit var tvStatus: TextView
+    private lateinit var btnGrant: MaterialButton
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        tvStatus = view.findViewById(R.id.tvWizardPermissionsStatus)
+        btnGrant = view.findViewById(R.id.btnWizardGrantPermissions)
+
+        btnGrant.setOnClickListener {
+            Permissions.showPermissionOnboarding(requireActivity(), onDeclined = { refreshStatus() })
+        }
+
+        refreshStatus()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshStatus()
+    }
+
+    fun refreshStatus() {
+        if (!isAdded) return
+
+        val granted = !Permissions.isAnyPermissionMissing(requireContext())
+        tvStatus.setText(
+            if (granted) R.string.wizard_step_permissions_status_granted else R.string.wizard_step_permissions_status_missing
+        )
+        btnGrant.visibility = if (granted) View.GONE else View.VISIBLE
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/ProfileStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/ProfileStepFragment.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.os.Bundle
+import android.view.View
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import androidx.fragment.app.Fragment
+import org.obd.graphs.R
+import org.obd.graphs.profile.profile
+
+class ProfileStepFragment : Fragment(R.layout.fragment_wizard_profile) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val radioGroup = view.findViewById<RadioGroup>(R.id.rgWizardProfiles)
+        val currentProfileId = profile.getCurrentProfile()
+
+        profile.getAvailableProfiles().forEach { (profileId, name) ->
+            val radioButton =
+                RadioButton(requireContext()).apply {
+                    id = View.generateViewId()
+                    text = name
+                    tag = profileId
+                }
+            radioGroup.addView(radioButton)
+            if (profileId == currentProfileId) {
+                radioGroup.check(radioButton.id)
+            }
+        }
+
+        radioGroup.setOnCheckedChangeListener { group, checkedId ->
+            val selectedProfileId = group.findViewById<RadioButton>(checkedId).tag as String
+            profile.saveCurrentProfile()
+            profile.loadProfile(selectedProfileId)
+        }
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/RunSetupWizardAction.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/RunSetupWizardAction.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.content.Context
+import android.content.Intent
+import android.util.AttributeSet
+import androidx.preference.Preference
+
+class RunSetupWizardAction(
+    context: Context,
+    attrs: AttributeSet?
+) : Preference(context, attrs) {
+    init {
+        setOnPreferenceClickListener {
+            context.startActivity(Intent(context, SetupWizardActivity::class.java))
+            true
+        }
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
@@ -42,6 +42,7 @@ class SetupWizardActivity :
     EasyPermissions.PermissionCallbacks {
     private val steps =
         listOf(
+            WizardStep(R.string.wizard_step_welcome_title) { WelcomeStepFragment() },
             WizardStep(R.string.wizard_step_language_title) { LanguageStepFragment() },
             WizardStep(R.string.wizard_step_permissions_title) { PermissionsStepFragment() },
             WizardStep(R.string.wizard_step_profile_title) { ProfileStepFragment() },

--- a/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.progressindicator.LinearProgressIndicator
+import org.obd.graphs.R
+import org.obd.graphs.language.LanguageManager
+import pub.devrel.easypermissions.EasyPermissions
+
+private data class WizardStep(
+    val titleResId: Int,
+    val fragmentFactory: () -> Fragment
+)
+
+class SetupWizardActivity :
+    AppCompatActivity(),
+    EasyPermissions.PermissionCallbacks {
+    private val steps =
+        listOf(
+            WizardStep(R.string.wizard_step_language_title) { LanguageStepFragment() },
+            WizardStep(R.string.wizard_step_permissions_title) { PermissionsStepFragment() },
+            WizardStep(R.string.wizard_step_profile_title) { ProfileStepFragment() },
+            WizardStep(R.string.wizard_step_adapter_title) { AdapterStepFragment() },
+            WizardStep(R.string.wizard_step_gdrive_title) { GoogleDriveStepFragment() },
+            WizardStep(R.string.wizard_step_views_title) { ViewsStepFragment() }
+        )
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LanguageManager.getLocalizedContext(newBase))
+    }
+
+    private var currentStep = 0
+
+    private lateinit var progress: LinearProgressIndicator
+    private lateinit var tvTitle: TextView
+    private lateinit var btnBack: MaterialButton
+    private lateinit var btnSkip: MaterialButton
+    private lateinit var btnNext: MaterialButton
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContentView(R.layout.activity_setup_wizard)
+        supportActionBar?.hide()
+
+        progress = findViewById(R.id.wizardProgress)
+        tvTitle = findViewById(R.id.tvWizardStepTitle)
+        btnBack = findViewById(R.id.btnWizardBack)
+        btnSkip = findViewById(R.id.btnWizardSkip)
+        btnNext = findViewById(R.id.btnWizardNext)
+
+        applyWindowInsets()
+
+        btnBack.setOnClickListener { goToStep(currentStep - 1) }
+        btnSkip.setOnClickListener { advance() }
+        btnNext.setOnClickListener { advance() }
+
+        goToStep(0)
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        EasyPermissions.onRequestPermissionsResult(requestCode, permissions, grantResults, this)
+    }
+
+    override fun onPermissionsGranted(
+        requestCode: Int,
+        perms: MutableList<String>
+    ) = refreshPermissionsStep()
+
+    override fun onPermissionsDenied(
+        requestCode: Int,
+        perms: MutableList<String>
+    ) = refreshPermissionsStep()
+
+    private fun refreshPermissionsStep() {
+        (supportFragmentManager.findFragmentById(R.id.wizardStepContainer) as? PermissionsStepFragment)?.refreshStatus()
+    }
+
+    private fun applyWindowInsets() {
+        val buttonBar = findViewById<View>(R.id.wizardButtonBar)
+        val buttonBarBasePadding = buttonBar.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.wizardRoot)) { _, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            progress.updatePadding(top = systemBars.top)
+            buttonBar.updatePadding(bottom = buttonBarBasePadding + systemBars.bottom)
+            insets
+        }
+    }
+
+    private fun advance() {
+        if (currentStep == steps.lastIndex) {
+            SetupWizardManager.markCompleted(this)
+            finish()
+        } else {
+            goToStep(currentStep + 1)
+        }
+    }
+
+    private fun goToStep(step: Int) {
+        currentStep = step
+        val wizardStep = steps[step]
+
+        tvTitle.text = getString(wizardStep.titleResId)
+        progress.progress = (step + 1) * 100 / steps.size
+
+        supportFragmentManager
+            .beginTransaction()
+            .replace(R.id.wizardStepContainer, wizardStep.fragmentFactory())
+            .commit()
+
+        btnBack.isEnabled = step > 0
+
+        val isLastStep = step == steps.lastIndex
+        btnNext.setText(if (isLastStep) R.string.wizard_action_finish else R.string.wizard_action_next)
+        btnSkip.visibility = if (isLastStep) View.GONE else View.VISIBLE
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
@@ -44,6 +44,7 @@ class SetupWizardActivity :
         listOf(
             WizardStep(R.string.wizard_step_welcome_title) { WelcomeStepFragment() },
             WizardStep(R.string.wizard_step_language_title) { LanguageStepFragment() },
+            WizardStep(R.string.wizard_step_theme_title) { ThemeStepFragment() },
             WizardStep(R.string.wizard_step_permissions_title) { PermissionsStepFragment() },
             WizardStep(R.string.wizard_step_profile_title) { ProfileStepFragment() },
             WizardStep(R.string.wizard_step_adapter_title) { AdapterStepFragment() },

--- a/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
@@ -47,6 +47,7 @@ class SetupWizardActivity :
             WizardStep(R.string.wizard_step_permissions_title) { PermissionsStepFragment() },
             WizardStep(R.string.wizard_step_profile_title) { ProfileStepFragment() },
             WizardStep(R.string.wizard_step_adapter_title) { AdapterStepFragment() },
+            WizardStep(R.string.wizard_step_test_connection_title) { TestConnectionStepFragment() },
             WizardStep(R.string.wizard_step_gdrive_title) { GoogleDriveStepFragment() },
             WizardStep(R.string.wizard_step_views_title) { ViewsStepFragment() },
             WizardStep(R.string.wizard_step_summary_title) { SummaryStepFragment() }

--- a/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/SetupWizardActivity.kt
@@ -48,7 +48,8 @@ class SetupWizardActivity :
             WizardStep(R.string.wizard_step_profile_title) { ProfileStepFragment() },
             WizardStep(R.string.wizard_step_adapter_title) { AdapterStepFragment() },
             WizardStep(R.string.wizard_step_gdrive_title) { GoogleDriveStepFragment() },
-            WizardStep(R.string.wizard_step_views_title) { ViewsStepFragment() }
+            WizardStep(R.string.wizard_step_views_title) { ViewsStepFragment() },
+            WizardStep(R.string.wizard_step_summary_title) { SummaryStepFragment() }
         )
 
     override fun attachBaseContext(newBase: Context) {

--- a/app/src/main/java/org/obd/graphs/wizard/SetupWizardManager.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/SetupWizardManager.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.content.Context
+
+private const val PREFS_FILE = "setup_wizard_prefs"
+private const val KEY_COMPLETED = "setup_wizard_completed"
+
+object SetupWizardManager {
+    fun shouldShowWizard(context: Context): Boolean {
+        if (isCompleted(context)) return false
+        val info = context.packageManager.getPackageInfo(context.packageName, 0)
+        return info.firstInstallTime == info.lastUpdateTime
+    }
+
+    fun isCompleted(context: Context): Boolean = prefs(context).getBoolean(KEY_COMPLETED, false)
+
+    fun markCompleted(context: Context) {
+        prefs(context).edit().putBoolean(KEY_COMPLETED, true).apply()
+    }
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+}

--- a/app/src/main/java/org/obd/graphs/wizard/SummaryStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/SummaryStepFragment.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import androidx.fragment.app.Fragment
+import org.obd.graphs.R
+
+class SummaryStepFragment : Fragment(R.layout.fragment_wizard_summary)

--- a/app/src/main/java/org/obd/graphs/wizard/TestConnectionStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/TestConnectionStepFragment.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.google.android.material.button.MaterialButton
+import org.obd.graphs.R
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_ADAPTER_NOT_SET_EVENT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_CONNECTED_EVENT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_CONNECTING_EVENT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_ERROR_CONNECT_EVENT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_ERROR_EVENT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_NO_NETWORK_EVENT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_WIFI_INCORRECT
+import org.obd.graphs.bl.datalogger.DATA_LOGGER_WIFI_NOT_CONNECTED
+import org.obd.graphs.bl.query.Query
+import org.obd.graphs.registerReceiver
+import org.obd.graphs.ui.common.toast
+import org.obd.graphs.ui.withDataLogger
+
+// Not a real deadline - some adapters (Bluetooth ELM327/STN handshakes especially) legitimately take
+// this long or more. It only surfaces an informational "still trying" message; it must never cancel
+// the attempt or race an in-flight CONNECTED_EVENT, since the real connection is still progressing.
+private const val CONNECTION_SLOW_WARNING_MS = 45_000L
+
+class TestConnectionStepFragment : Fragment(R.layout.fragment_wizard_test_connection) {
+    private lateinit var tvStatus: TextView
+    private lateinit var btnTest: MaterialButton
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val slowWarningRunnable =
+        Runnable { updateStatus(R.string.wizard_step_test_connection_status_slow, enableButton = false) }
+
+    private val receiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context?,
+                intent: Intent?
+            ) {
+                when (intent?.action) {
+                    DATA_LOGGER_CONNECTING_EVENT -> updateStatus(R.string.wizard_step_test_connection_status_connecting, enableButton = false)
+                    DATA_LOGGER_CONNECTED_EVENT -> onResult(R.string.wizard_step_test_connection_status_connected)
+                    DATA_LOGGER_ADAPTER_NOT_SET_EVENT -> onResult(R.string.wizard_step_test_connection_status_no_adapter)
+                    DATA_LOGGER_ERROR_CONNECT_EVENT,
+                    DATA_LOGGER_ERROR_EVENT,
+                    DATA_LOGGER_WIFI_INCORRECT,
+                    DATA_LOGGER_WIFI_NOT_CONNECTED,
+                    DATA_LOGGER_NO_NETWORK_EVENT -> onResult(R.string.wizard_step_test_connection_status_failed)
+                }
+            }
+        }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        tvStatus = view.findViewById(R.id.tvWizardTestConnectionStatus)
+        btnTest = view.findViewById(R.id.btnWizardTestConnection)
+
+        btnTest.setOnClickListener {
+            updateStatus(R.string.wizard_step_test_connection_status_connecting, enableButton = false)
+            handler.postDelayed(slowWarningRunnable, CONNECTION_SLOW_WARNING_MS)
+            withDataLogger { start(Query.instance()) }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
+        registerReceiver(requireContext(), receiver) {
+            it.addAction(DATA_LOGGER_CONNECTING_EVENT)
+            it.addAction(DATA_LOGGER_CONNECTED_EVENT)
+            it.addAction(DATA_LOGGER_ADAPTER_NOT_SET_EVENT)
+            it.addAction(DATA_LOGGER_ERROR_CONNECT_EVENT)
+            it.addAction(DATA_LOGGER_ERROR_EVENT)
+            it.addAction(DATA_LOGGER_WIFI_INCORRECT)
+            it.addAction(DATA_LOGGER_WIFI_NOT_CONNECTED)
+            it.addAction(DATA_LOGGER_NO_NETWORK_EVENT)
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+        handler.removeCallbacks(slowWarningRunnable)
+        requireContext().unregisterReceiver(receiver)
+    }
+
+    // Only real, system-reported outcomes (a CONNECTED_EVENT or an actual error event) are treated as
+    // final and stop the test connection - the slow-warning message above is not authoritative.
+    private fun onResult(textRes: Int) {
+        handler.removeCallbacks(slowWarningRunnable)
+        updateStatus(textRes, enableButton = true)
+        toast(textRes)
+        withDataLogger { stop() }
+    }
+
+    private fun updateStatus(
+        textRes: Int,
+        enableButton: Boolean
+    ) {
+        if (!isAdded) return
+        tvStatus.setText(textRes)
+        btnTest.isEnabled = enableButton
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/ThemeStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/ThemeStepFragment.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.os.Bundle
+import android.view.View
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import androidx.fragment.app.Fragment
+import org.obd.graphs.R
+import org.obd.graphs.theme.THEME_DARK
+import org.obd.graphs.theme.THEME_LIGHT
+import org.obd.graphs.theme.THEME_SYSTEM
+import org.obd.graphs.theme.ThemeManager
+
+class ThemeStepFragment : Fragment(R.layout.fragment_wizard_theme) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val radioGroup = view.findViewById<RadioGroup>(R.id.rgWizardTheme)
+        val rbSystem = view.findViewById<RadioButton>(R.id.rbWizardThemeSystem)
+        val rbLight = view.findViewById<RadioButton>(R.id.rbWizardThemeLight)
+        val rbDark = view.findViewById<RadioButton>(R.id.rbWizardThemeDark)
+
+        when (ThemeManager.getStoredTheme(requireContext())) {
+            THEME_LIGHT -> rbLight.isChecked = true
+            THEME_DARK -> rbDark.isChecked = true
+            else -> rbSystem.isChecked = true
+        }
+
+        radioGroup.setOnCheckedChangeListener { _, checkedId ->
+            val theme =
+                when (checkedId) {
+                    R.id.rbWizardThemeLight -> THEME_LIGHT
+                    R.id.rbWizardThemeDark -> THEME_DARK
+                    else -> THEME_SYSTEM
+                }
+            ThemeManager.saveTheme(requireContext(), theme)
+        }
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/ViewsStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/ViewsStepFragment.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import android.os.Bundle
+import android.view.Gravity
+import android.view.View
+import android.widget.CheckBox
+import android.widget.LinearLayout
+import androidx.fragment.app.Fragment
+import com.google.android.material.button.MaterialButton
+import org.obd.graphs.R
+import org.obd.graphs.preferences.Prefs
+import org.obd.graphs.preferences.pid.PidDefinitionDialogFragment
+import org.obd.graphs.preferences.updateBoolean
+
+private data class ViewOption(
+    val titleResId: Int,
+    val enabledPrefKey: String,
+    val defaultEnabled: Boolean,
+    val pidsKey: String? = null,
+    val pidsSource: String? = null
+)
+
+private val WIZARD_VIEW_OPTIONS =
+    listOf(
+        ViewOption(R.string.navigation_title_gauge, "pref.gauge.view.enabled", true, "pref.gauge.displayed_parameter_ids", "gauge"),
+        ViewOption(R.string.navigation_title_dashboard, "pref.dash.view.enabled", false, "pref.dash.displayed_parameter_ids", "dashboard"),
+        ViewOption(
+            R.string.navigation_title_performance,
+            "pref.performance.view.enabled",
+            false,
+            "pref.performance.displayed_parameter_ids",
+            "performance"
+        ),
+        ViewOption(
+            R.string.navigation_title_trip_info,
+            "pref.trip_info.view.enabled",
+            false,
+            "pref.trip_info.displayed_parameter_ids",
+            "trip_info"
+        ),
+        ViewOption(R.string.navigation_title_graph, "pref.graph.view.enabled", true, "pref.graph.displayed_parameter_ids", "graph"),
+        ViewOption(R.string.navigation_title_giulia, "pref.giulia.view.enabled", true, "pref.giulia.displayed_parameter_ids", "giulia"),
+        ViewOption(R.string.navigation_title_drag_racing, "pref.drag_racing.view.enabled", false)
+    )
+
+class ViewsStepFragment : Fragment(R.layout.fragment_wizard_views) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val container = view.findViewById<LinearLayout>(R.id.llWizardViews)
+
+        WIZARD_VIEW_OPTIONS.forEach { option ->
+            val row =
+                LinearLayout(requireContext()).apply {
+                    orientation = LinearLayout.HORIZONTAL
+                    gravity = Gravity.CENTER_VERTICAL
+                }
+
+            val checkBox =
+                CheckBox(requireContext()).apply {
+                    layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                    text = getString(option.titleResId)
+                    isChecked = Prefs.getBoolean(option.enabledPrefKey, option.defaultEnabled)
+                    setOnCheckedChangeListener { _, checked -> Prefs.updateBoolean(option.enabledPrefKey, checked) }
+                }
+            row.addView(checkBox)
+
+            if (option.pidsKey != null && option.pidsSource != null) {
+                val selectPidsButton =
+                    MaterialButton(requireContext()).apply {
+                        text = getString(R.string.wizard_step_views_select_pids)
+                        setOnClickListener {
+                            PidDefinitionDialogFragment(key = option.pidsKey, source = option.pidsSource)
+                                .show(childFragmentManager, null)
+                        }
+                    }
+                row.addView(selectPidsButton)
+            }
+
+            container.addView(row)
+        }
+    }
+}

--- a/app/src/main/java/org/obd/graphs/wizard/ViewsStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/ViewsStepFragment.kt
@@ -24,38 +24,52 @@ import android.widget.LinearLayout
 import androidx.fragment.app.Fragment
 import com.google.android.material.button.MaterialButton
 import org.obd.graphs.R
+import org.obd.graphs.activity.NAVIGATION_BUTTONS_VISIBILITY_CHANGED
+import org.obd.graphs.bl.trip.tripVirtualScreenManager
 import org.obd.graphs.preferences.Prefs
 import org.obd.graphs.preferences.pid.PidDefinitionDialogFragment
 import org.obd.graphs.preferences.updateBoolean
+import org.obd.graphs.sendBroadcastEvent
+import org.obd.graphs.ui.gauge.gaugeVirtualScreenPreferences
+import org.obd.graphs.ui.giulia.giuliaVirtualScreenPreferences
 
 private data class ViewOption(
     val titleResId: Int,
     val enabledPrefKey: String,
     val defaultEnabled: Boolean,
-    val pidsKey: String? = null,
+    val pidsKeyProvider: (() -> String)? = null,
     val pidsSource: String? = null
 )
 
+// Keys mirror PreferencesFragment.onDisplayPreferenceDialog()'s dispatch exactly: gauge/giulia/graph
+// are per-"virtual screen" keys (NOT the PidDefinitionListPreferences widget's own android:key), dash
+// is a flat literal, and performance/trip_info do use the widget's own key.
 private val WIZARD_VIEW_OPTIONS =
     listOf(
-        ViewOption(R.string.navigation_title_gauge, "pref.gauge.view.enabled", true, "pref.gauge.displayed_parameter_ids", "gauge"),
-        ViewOption(R.string.navigation_title_dashboard, "pref.dash.view.enabled", false, "pref.dash.displayed_parameter_ids", "dashboard"),
+        ViewOption(R.string.navigation_title_gauge, "pref.gauge.view.enabled", true, { gaugeVirtualScreenPreferences.getVirtualScreenPrefKey() }, "gauge"),
+        ViewOption(R.string.navigation_title_dashboard, "pref.dash.view.enabled", false, { "pref.dash.pids.selected" }, "dashboard"),
         ViewOption(
             R.string.navigation_title_performance,
             "pref.performance.view.enabled",
             false,
-            "pref.performance.displayed_parameter_ids",
+            { "pref.performance.displayed_parameter_ids" },
             "performance"
         ),
         ViewOption(
             R.string.navigation_title_trip_info,
             "pref.trip_info.view.enabled",
             false,
-            "pref.trip_info.displayed_parameter_ids",
+            { "pref.trip_info.displayed_parameter_ids" },
             "trip_info"
         ),
-        ViewOption(R.string.navigation_title_graph, "pref.graph.view.enabled", true, "pref.graph.displayed_parameter_ids", "graph"),
-        ViewOption(R.string.navigation_title_giulia, "pref.giulia.view.enabled", true, "pref.giulia.displayed_parameter_ids", "giulia"),
+        ViewOption(R.string.navigation_title_graph, "pref.graph.view.enabled", true, { tripVirtualScreenManager.getVirtualScreenPrefKey() }, "graph"),
+        ViewOption(
+            R.string.navigation_title_giulia,
+            "pref.giulia.view.enabled",
+            true,
+            { giuliaVirtualScreenPreferences.getVirtualScreenPrefKey() },
+            "giulia"
+        ),
         ViewOption(R.string.navigation_title_drag_racing, "pref.drag_racing.view.enabled", false)
     )
 
@@ -80,16 +94,20 @@ class ViewsStepFragment : Fragment(R.layout.fragment_wizard_views) {
                     layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
                     text = getString(option.titleResId)
                     isChecked = Prefs.getBoolean(option.enabledPrefKey, option.defaultEnabled)
-                    setOnCheckedChangeListener { _, checked -> Prefs.updateBoolean(option.enabledPrefKey, checked) }
+                    setOnCheckedChangeListener { _, checked ->
+                        Prefs.updateBoolean(option.enabledPrefKey, checked)
+                        // Refreshes both the bottom nav bar and the drawer for all views in one call.
+                        sendBroadcastEvent(NAVIGATION_BUTTONS_VISIBILITY_CHANGED)
+                    }
                 }
             row.addView(checkBox)
 
-            if (option.pidsKey != null && option.pidsSource != null) {
+            if (option.pidsKeyProvider != null && option.pidsSource != null) {
                 val selectPidsButton =
                     MaterialButton(requireContext()).apply {
                         text = getString(R.string.wizard_step_views_select_pids)
                         setOnClickListener {
-                            PidDefinitionDialogFragment(key = option.pidsKey, source = option.pidsSource)
+                            PidDefinitionDialogFragment(key = option.pidsKeyProvider.invoke(), source = option.pidsSource)
                                 .show(childFragmentManager, null)
                         }
                     }

--- a/app/src/main/java/org/obd/graphs/wizard/WelcomeStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/WelcomeStepFragment.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.wizard
+
+import androidx.fragment.app.Fragment
+import org.obd.graphs.R
+
+class WelcomeStepFragment : Fragment(R.layout.fragment_wizard_welcome)

--- a/app/src/main/res/layout/activity_setup_wizard.xml
+++ b/app/src/main/res/layout/activity_setup_wizard.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/wizardRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:orientation="vertical">
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/wizardProgress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:max="100"
+        app:trackThickness="4dp" />
+
+    <TextView
+        android:id="@+id/tvWizardStepTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:textAppearance="?attr/textAppearanceHeadline6" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/wizardStepContainer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <LinearLayout
+        android:id="@+id/wizardButtonBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnWizardBack"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/wizard.action_back" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_weight="1" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnWizardSkip"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:text="@string/wizard.action_skip" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnWizardNext"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/wizard.action_next" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wizard_gdrive.xml
+++ b/app/src/main/res/layout/fragment_wizard_gdrive.xml
@@ -9,9 +9,16 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="24dp"
+        android:layout_marginBottom="16dp"
         android:text="@string/wizard_step_gdrive_description"
         android:textColor="?android:attr/textColorSecondary" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:text="@string/wizard_step_gdrive_wifi_hint"
+        android:textStyle="bold" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btnWizardConnectDrive"

--- a/app/src/main/res/layout/fragment_wizard_gdrive.xml
+++ b/app/src/main/res/layout/fragment_wizard_gdrive.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:text="@string/wizard_step_gdrive_description"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnWizardConnectDrive"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/wizard_step_gdrive_connect_button" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wizard_language.xml
+++ b/app/src/main/res/layout/fragment_wizard_language.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/wizard_step_language_description"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvWizardLanguages"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wizard_permissions.xml
+++ b/app/src/main/res/layout/fragment_wizard_permissions.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/wizard_step_permissions_description"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <TextView
+        android:id="@+id/tvWizardPermissionsStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:textStyle="bold" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnWizardGrantPermissions"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/wizard_step_permissions_grant_button" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wizard_profile.xml
+++ b/app/src/main/res/layout/fragment_wizard_profile.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/wizard_step_profile_description"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <RadioGroup
+            android:id="@+id/rgWizardProfiles"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_wizard_summary.xml
+++ b/app/src/main/res/layout/fragment_wizard_summary.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:gravity="center_horizontal"
+        android:text="@string/wizard_step_summary_intro"
+        android:textColor="?android:attr/textColorPrimary"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:text="@string/wizard_step_summary_description"
+        android:textColor="?android:attr/textColorSecondary" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wizard_test_connection.xml
+++ b/app/src/main/res/layout/fragment_wizard_test_connection.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/wizard_step_test_connection_description"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <TextView
+        android:id="@+id/tvWizardTestConnectionStatus"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:text="@string/wizard_step_test_connection_status_idle"
+        android:textStyle="bold" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnWizardTestConnection"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/wizard_step_test_connection_button" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wizard_theme.xml
+++ b/app/src/main/res/layout/fragment_wizard_theme.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/wizard_step_theme_description"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <RadioGroup
+        android:id="@+id/rgWizardTheme"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <RadioButton
+            android:id="@+id/rbWizardThemeSystem"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/wizard_step_theme_system" />
+
+        <RadioButton
+            android:id="@+id/rbWizardThemeLight"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/wizard_step_theme_light" />
+
+        <RadioButton
+            android:id="@+id/rbWizardThemeDark"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/wizard_step_theme_dark" />
+    </RadioGroup>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_wizard_views.xml
+++ b/app/src/main/res/layout/fragment_wizard_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/wizard_step_views_description"
+            android:textColor="?android:attr/textColorSecondary" />
+
+        <LinearLayout
+            android:id="@+id/llWizardViews"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_wizard_welcome.xml
+++ b/app/src/main/res/layout/fragment_wizard_welcome.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/wizard_step_welcome_intro"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="16sp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/wizard_step_welcome_description"
+            android:textColor="?android:attr/textColorSecondary" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -668,6 +668,21 @@
     <string name="wizard_step_language_title">Język</string>
     <string name="wizard_step_language_description">Wybierz język aplikacji. Możesz to zmienić w dowolnym momencie w Ustawieniach.</string>
 
+    <string name="pref.app.theme_title">Motyw aplikacji</string>
+    <string name="pref.app.theme_summary">Wybierz wygląd aplikacji</string>
+
+    <string-array name="pref.app_theme_entries">
+        <item>Domyślny systemowy</item>
+        <item>Jasny</item>
+        <item>Ciemny</item>
+    </string-array>
+
+    <string name="wizard_step_theme_title">Motyw</string>
+    <string name="wizard_step_theme_description">Wybierz wygląd aplikacji. Możesz to zmienić w dowolnym momencie w Ustawieniach.</string>
+    <string name="wizard_step_theme_system">Domyślny systemowy</string>
+    <string name="wizard_step_theme_light">Jasny</string>
+    <string name="wizard_step_theme_dark">Ciemny</string>
+
     <string name="wizard_step_permissions_title">Uprawnienia</string>
     <string name="wizard_step_permissions_description">Aplikacja potrzebuje uprawnień lokalizacji, Bluetooth i powiadomień, aby połączyć się z adapterem OBD i rejestrować trasy.</string>
     <string name="wizard_step_permissions_status_granted">Wszystkie uprawnienia przyznane.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -661,6 +661,10 @@
     <string name="wizard.action_next">Dalej</string>
     <string name="wizard_action_finish">Zakończ</string>
 
+    <string name="wizard_step_welcome_title">Witamy</string>
+    <string name="wizard_step_welcome_intro">Witamy! Skonfigurujmy aplikację.</string>
+    <string name="wizard_step_welcome_description">Ta aplikacja łączy się z adapterem OBD2 pojazdu, aby zbierać i wizualizować dane telemetryczne w czasie rzeczywistym.\n\nCo możesz zrobić:\n\n• Śledzić na żywo wskaźniki, dashboard i ekrany wydajności\n• Rejestrować trasy z GPS i przeglądać je później\n• Mierzyć przyspieszenie za pomocą stopera Drag Racing\n• Tworzyć i zarządzać profilami pojazdów dla różnych samochodów i adapterów\n• Dodawać własne PID-y i formuły\n• Tworzyć kopie zapasowe ustawień, własnych PID-ów i tras na Dysku Google\n\nKolejne kroki pomogą skonfigurować podstawy - wszystko możesz później zmienić w Ustawieniach.</string>
+
     <string name="wizard_step_language_title">Język</string>
     <string name="wizard_step_language_description">Wybierz język aplikacji. Możesz to zmienić w dowolnym momencie w Ustawieniach.</string>
 
@@ -677,6 +681,7 @@
 
     <string name="wizard_step_gdrive_title">Dysk Google</string>
     <string name="wizard_step_gdrive_description">Połącz Dysk Google, aby tworzyć kopie zapasowe ustawień, własnych PID-ów i tras. Możesz pominąć ten krok i połączyć się później.</string>
+    <string name="wizard_step_gdrive_wifi_hint">Aby połączyć się z Dyskiem Google, musi być włączone Wi-Fi.</string>
     <string name="wizard_step_gdrive_connect_button">Połącz Dysk Google</string>
 
     <string name="wizard_step_views_title">Widoki i PID-y</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -679,6 +679,16 @@
 
     <string name="wizard_step_adapter_title">Adapter OBD</string>
 
+    <string name="wizard_step_test_connection_title">Test połączenia</string>
+    <string name="wizard_step_test_connection_description">Spróbuj teraz połączyć się z adapterem OBD, aby upewnić się, że wszystko jest poprawnie skonfigurowane. Możesz pominąć ten krok i połączyć się później.</string>
+    <string name="wizard_step_test_connection_button">Testuj połączenie</string>
+    <string name="wizard_step_test_connection_status_idle">Jeszcze nie testowano.</string>
+    <string name="wizard_step_test_connection_status_connecting">Łączenie…</string>
+    <string name="wizard_step_test_connection_status_connected">Połączono pomyślnie!</string>
+    <string name="wizard_step_test_connection_status_no_adapter">Nie wybrano adaptera. Wróć i skonfiguruj go.</string>
+    <string name="wizard_step_test_connection_status_failed">Połączenie nie powiodło się. Sprawdź ustawienia adaptera i spróbuj ponownie.</string>
+    <string name="wizard_step_test_connection_status_slow">Nadal trwa łączenie… niektóre adaptery potrzebują więcej czasu. Upewnij się, że jest włączony i w zasięgu.</string>
+
     <string name="wizard_step_gdrive_title">Dysk Google</string>
     <string name="wizard_step_gdrive_description">Połącz Dysk Google, aby tworzyć kopie zapasowe ustawień, własnych PID-ów i tras. Możesz pominąć ten krok i połączyć się później.</string>
     <string name="wizard_step_gdrive_wifi_hint">Aby połączyć się z Dyskiem Google, musi być włączone Wi-Fi.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -652,4 +652,35 @@
     <string name="gps.debug_log">Dziennik debugowania</string>
     <string name="gps.initializing">Inicjalizacja&#8230;</string>
 
+    <string name="pref.wizard.rerun_title">Uruchom kreatora konfiguracji</string>
+    <string name="pref.wizard.rerun_summary">Uruchom ponownie konfigurację profilu, adaptera, Dysku Google i widoków</string>
+
+    <string name="wizard_title">Kreator konfiguracji</string>
+    <string name="wizard.action_back">Wstecz</string>
+    <string name="wizard.action_skip">Pomiń</string>
+    <string name="wizard.action_next">Dalej</string>
+    <string name="wizard_action_finish">Zakończ</string>
+
+    <string name="wizard_step_language_title">Język</string>
+    <string name="wizard_step_language_description">Wybierz język aplikacji. Możesz to zmienić w dowolnym momencie w Ustawieniach.</string>
+
+    <string name="wizard_step_permissions_title">Uprawnienia</string>
+    <string name="wizard_step_permissions_description">Aplikacja potrzebuje uprawnień lokalizacji, Bluetooth i powiadomień, aby połączyć się z adapterem OBD i rejestrować trasy.</string>
+    <string name="wizard_step_permissions_status_granted">Wszystkie uprawnienia przyznane.</string>
+    <string name="wizard_step_permissions_status_missing">Brakuje niektórych uprawnień.</string>
+    <string name="wizard_step_permissions_grant_button">Przyznaj uprawnienia</string>
+
+    <string name="wizard_step_profile_title">Profil pojazdu</string>
+    <string name="wizard_step_profile_description">Wybierz profil pojazdu, od którego chcesz zacząć. Możesz to zmienić w dowolnym momencie w Ustawieniach.</string>
+
+    <string name="wizard_step_adapter_title">Adapter OBD</string>
+
+    <string name="wizard_step_gdrive_title">Dysk Google</string>
+    <string name="wizard_step_gdrive_description">Połącz Dysk Google, aby tworzyć kopie zapasowe ustawień, własnych PID-ów i tras. Możesz pominąć ten krok i połączyć się później.</string>
+    <string name="wizard_step_gdrive_connect_button">Połącz Dysk Google</string>
+
+    <string name="wizard_step_views_title">Widoki i PID-y</string>
+    <string name="wizard_step_views_description">Wybierz, które widoki mają być widoczne oraz, opcjonalnie, jakie PID-y mają być na nich wyświetlane.</string>
+    <string name="wizard_step_views_select_pids">Wybierz PID-y</string>
+
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -688,4 +688,8 @@
     <string name="wizard_step_views_description">Wybierz, które widoki mają być widoczne oraz, opcjonalnie, jakie PID-y mają być na nich wyświetlane.</string>
     <string name="wizard_step_views_select_pids">Wybierz PID-y</string>
 
+    <string name="wizard_step_summary_title">Gotowe</string>
+    <string name="wizard_step_summary_intro">Wszystko gotowe!</string>
+    <string name="wizard_step_summary_description">Aplikacja jest skonfigurowana i gotowa do użycia. Możesz wrócić do tych ustawień w dowolnym momencie w Ustawieniach lub uruchomić ponownie tego kreatora z pozycji \"Uruchom kreatora konfiguracji\" na górze Ustawień.</string>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -895,6 +895,10 @@
     <string name="wizard.action_next">Next</string>
     <string name="wizard_action_finish">Finish</string>
 
+    <string name="wizard_step_welcome_title">Welcome</string>
+    <string name="wizard_step_welcome_intro">Welcome! Let\'s get your app set up.</string>
+    <string name="wizard_step_welcome_description">This app connects to your vehicle\'s OBD2 adapter to collect and visualize real-time telemetry data.\n\nWhat you can do:\n\n• Monitor live gauges, dashboards and performance screens\n• Log trips with GPS and review them later\n• Track acceleration with the Drag Racing timer\n• Create and manage vehicle profiles for different cars and adapters\n• Add your own custom PIDs and formulas\n• Back up your settings, custom PIDs and trips to Google Drive\n\nThe next few steps will help you configure the basics - you can change any of it later in Preferences.</string>
+
     <string name="wizard_step_language_title">Language</string>
     <string name="wizard_step_language_description">Choose the app language. You can change this anytime in Preferences.</string>
 
@@ -911,6 +915,7 @@
 
     <string name="wizard_step_gdrive_title">Google Drive</string>
     <string name="wizard_step_gdrive_description">Connect Google Drive to back up your settings, custom PIDs and trip logs. You can skip this and connect later.</string>
+    <string name="wizard_step_gdrive_wifi_hint">Wi-Fi must be enabled to connect to Google Drive.</string>
     <string name="wizard_step_gdrive_connect_button">Connect Google Drive</string>
 
     <string name="wizard_step_views_title">Views &amp; PIDs</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -921,4 +921,8 @@
     <string name="wizard_step_views_title">Views &amp; PIDs</string>
     <string name="wizard_step_views_description">Choose which views to show and, optionally, which PIDs to display on each.</string>
     <string name="wizard_step_views_select_pids">Select PIDs</string>
+
+    <string name="wizard_step_summary_title">All Set</string>
+    <string name="wizard_step_summary_intro">You\'re all set!</string>
+    <string name="wizard_step_summary_description">Your app is configured and ready to go. You can revisit any of these settings anytime in Preferences, or re-run this wizard from the \"Run Setup Wizard\" entry at the top of Preferences.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -913,6 +913,16 @@
 
     <string name="wizard_step_adapter_title">OBD Adapter</string>
 
+    <string name="wizard_step_test_connection_title">Test Connection</string>
+    <string name="wizard_step_test_connection_description">Try connecting to your OBD adapter now to make sure everything is configured correctly. You can skip this and connect later.</string>
+    <string name="wizard_step_test_connection_button">Test Connection</string>
+    <string name="wizard_step_test_connection_status_idle">Not tested yet.</string>
+    <string name="wizard_step_test_connection_status_connecting">Connecting…</string>
+    <string name="wizard_step_test_connection_status_connected">Connected successfully!</string>
+    <string name="wizard_step_test_connection_status_no_adapter">No adapter selected. Please go back and configure one.</string>
+    <string name="wizard_step_test_connection_status_failed">Connection failed. Check your adapter settings and try again.</string>
+    <string name="wizard_step_test_connection_status_slow">Still trying to connect… some adapters take longer. Make sure it\'s powered on and in range.</string>
+
     <string name="wizard_step_gdrive_title">Google Drive</string>
     <string name="wizard_step_gdrive_description">Connect Google Drive to back up your settings, custom PIDs and trip logs. You can skip this and connect later.</string>
     <string name="wizard_step_gdrive_wifi_hint">Wi-Fi must be enabled to connect to Google Drive.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -902,6 +902,27 @@
     <string name="wizard_step_language_title">Language</string>
     <string name="wizard_step_language_description">Choose the app language. You can change this anytime in Preferences.</string>
 
+    <string name="pref.app.theme_title">App Theme</string>
+    <string name="pref.app.theme_summary">Choose how the app should look</string>
+
+    <string-array name="pref.app_theme_entries">
+        <item>System Default</item>
+        <item>Light</item>
+        <item>Dark</item>
+    </string-array>
+
+    <string-array name="pref.app_theme_values">
+        <item>system</item>
+        <item>light</item>
+        <item>dark</item>
+    </string-array>
+
+    <string name="wizard_step_theme_title">Theme</string>
+    <string name="wizard_step_theme_description">Choose how the app should look. You can change this anytime in Preferences.</string>
+    <string name="wizard_step_theme_system">System Default</string>
+    <string name="wizard_step_theme_light">Light</string>
+    <string name="wizard_step_theme_dark">Dark</string>
+
     <string name="wizard_step_permissions_title">Permissions</string>
     <string name="wizard_step_permissions_description">The app needs Location, Bluetooth and Notification permissions to connect to your OBD adapter and log trips.</string>
     <string name="wizard_step_permissions_status_granted">All permissions granted.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -885,4 +885,35 @@
         <item>en</item>
         <item>pl</item>
     </string-array>
+
+    <string name="pref.wizard.rerun_title">Run Setup Wizard</string>
+    <string name="pref.wizard.rerun_summary">Re-run the profile, adapter, Google Drive and views setup steps</string>
+
+    <string name="wizard_title">Setup Wizard</string>
+    <string name="wizard.action_back">Back</string>
+    <string name="wizard.action_skip">Skip</string>
+    <string name="wizard.action_next">Next</string>
+    <string name="wizard_action_finish">Finish</string>
+
+    <string name="wizard_step_language_title">Language</string>
+    <string name="wizard_step_language_description">Choose the app language. You can change this anytime in Preferences.</string>
+
+    <string name="wizard_step_permissions_title">Permissions</string>
+    <string name="wizard_step_permissions_description">The app needs Location, Bluetooth and Notification permissions to connect to your OBD adapter and log trips.</string>
+    <string name="wizard_step_permissions_status_granted">All permissions granted.</string>
+    <string name="wizard_step_permissions_status_missing">Some permissions are missing.</string>
+    <string name="wizard_step_permissions_grant_button">Grant Permissions</string>
+
+    <string name="wizard_step_profile_title">Vehicle Profile</string>
+    <string name="wizard_step_profile_description">Pick the vehicle profile you want to start with. You can change this anytime in Preferences.</string>
+
+    <string name="wizard_step_adapter_title">OBD Adapter</string>
+
+    <string name="wizard_step_gdrive_title">Google Drive</string>
+    <string name="wizard_step_gdrive_description">Connect Google Drive to back up your settings, custom PIDs and trip logs. You can skip this and connect later.</string>
+    <string name="wizard_step_gdrive_connect_button">Connect Google Drive</string>
+
+    <string name="wizard_step_views_title">Views &amp; PIDs</string>
+    <string name="wizard_step_views_description">Choose which views to show and, optionally, which PIDs to display on each.</string>
+    <string name="wizard_step_views_select_pids">Select PIDs</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -8,6 +8,12 @@
         android:summary="@string/pref.language.summary"
         android:persistent="false" />
 
+    <org.obd.graphs.wizard.RunSetupWizardAction
+        android:key="pref.wizard.rerun"
+        android:title="@string/pref.wizard.rerun_title"
+        android:summary="@string/pref.wizard.rerun_summary"
+        android:persistent="false" />
+
     <PreferenceCategory android:title="@string/pref.trips.title">
         <org.obd.graphs.preferences.DriveAutoSyncEnablerCheckBoxPreference
                 android:defaultValue="false"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -14,6 +14,14 @@
         android:summary="@string/pref.wizard.rerun_summary"
         android:persistent="false" />
 
+    <org.obd.graphs.preferences.ThemeListPreference
+        android:entries="@array/pref.app_theme_entries"
+        android:entryValues="@array/pref.app_theme_values"
+        android:key="pref.app.theme"
+        android:title="@string/pref.app.theme_title"
+        android:persistent="false"
+        app:useSimpleSummaryProvider="true" />
+
     <PreferenceCategory android:title="@string/pref.trips.title">
         <org.obd.graphs.preferences.DriveAutoSyncEnablerCheckBoxPreference
                 android:defaultValue="false"

--- a/common/src/main/java/org/obd/graphs/theme/ThemeManager.kt
+++ b/common/src/main/java/org/obd/graphs/theme/ThemeManager.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.theme
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
+
+private const val PREFS_FILE = "theme_prefs"
+private const val KEY_THEME = "theme"
+
+const val THEME_SYSTEM = "system"
+const val THEME_LIGHT = "light"
+const val THEME_DARK = "dark"
+
+object ThemeManager {
+    fun getStoredTheme(context: Context): String =
+        context
+            .getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+            .getString(KEY_THEME, THEME_SYSTEM) ?: THEME_SYSTEM
+
+    // AppCompatDelegate.setDefaultNightMode() is process-global and automatically recreates every
+    // currently-resumed AppCompatActivity, so there's no per-Activity attachBaseContext equivalent needed.
+    fun saveTheme(
+        context: Context,
+        theme: String
+    ) {
+        context
+            .getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_THEME, theme)
+            .apply()
+        applyTheme(theme)
+    }
+
+    fun applyStoredTheme(context: Context) {
+        applyTheme(getStoredTheme(context))
+    }
+
+    private fun applyTheme(theme: String) {
+        AppCompatDelegate.setDefaultNightMode(
+            when (theme) {
+                THEME_LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+                THEME_DARK -> AppCompatDelegate.MODE_NIGHT_YES
+                else -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+            }
+        )
+    }
+}


### PR DESCRIPTION
Add a 6-step setup wizard (Language, Permissions, Profile, Adapter, Google Drive, Views) that runs once after a genuinely fresh install, gated by SetupWizardManager (own SharedPreferences flag + a firstInstallTime == lastUpdateTime check so existing users updating to this version never see it). Every step is skippable and it's re-runnable anytime via a new "Run Setup Wizard" entry in Preferences.

Each step reuses existing, already-working pieces instead of new picker UI: profile.getAvailableProfiles()/loadProfile() for Profile, the existing pref.adapter.connection PreferenceScreen subtree for Adapter, TripLogDriveManager.authenticate() for Google Drive, PidDefinitionDialogFragment for PID selection, and LanguageAdapter/LanguageManager and Permissions.showPermissionOnboarding() for Language/Permissions - the latter two also removed from MainActivity.runWizardFlow()'s standalone dialogs when the wizard is about to handle them, so fresh installs aren't asked twice.

Fixes along the way:
- SetupWizardActivity now overrides attachBaseContext() and hides its ActionBar (it was rendering system-locale-only and double-titled).
- Applies system-bar insets to the wizard's progress bar and button bar, since the app targets SDK 35 (edge-to-edge enforced) and this new Activity never opted into any inset handling.
- GoogleDriveStepFragment constructs its TripLogDriveManager in onCreate() instead of on click: AuthorizationManager registers an ActivityResultLauncher in its constructor, which Android requires before the fragment reaches STARTED - doing it lazily on click threw and tore down the wizard.
- MainActivity.onResume() recreates itself if the locale was changed by the wizard while MainActivity was paused underneath it.