### PR TITLE
feat(wizard): show real per-profile description, fixed detail panel

### DIFF
--- a/app/src/main/java/org/obd/graphs/wizard/ProfileStepFragment.kt
+++ b/app/src/main/java/org/obd/graphs/wizard/ProfileStepFragment.kt
@@ -20,9 +20,14 @@ import android.os.Bundle
 import android.view.View
 import android.widget.RadioButton
 import android.widget.RadioGroup
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import org.obd.graphs.R
+import org.obd.graphs.preferences.Prefs
+import org.obd.graphs.preferences.getString
 import org.obd.graphs.profile.profile
+
+private const val PREF_PROFILE_ABOUT = "pref.profile.about"
 
 class ProfileStepFragment : Fragment(R.layout.fragment_wizard_profile) {
     override fun onViewCreated(
@@ -32,6 +37,7 @@ class ProfileStepFragment : Fragment(R.layout.fragment_wizard_profile) {
         super.onViewCreated(view, savedInstanceState)
 
         val radioGroup = view.findViewById<RadioGroup>(R.id.rgWizardProfiles)
+        val tvDetail = view.findViewById<TextView>(R.id.tvWizardProfileDetail)
         val currentProfileId = profile.getCurrentProfile()
 
         profile.getAvailableProfiles().forEach { (profileId, name) ->
@@ -47,10 +53,17 @@ class ProfileStepFragment : Fragment(R.layout.fragment_wizard_profile) {
             }
         }
 
+        tvDetail.text = profileAbout(currentProfileId)
+
         radioGroup.setOnCheckedChangeListener { group, checkedId ->
             val selectedProfileId = group.findViewById<RadioButton>(checkedId).tag as String
             profile.saveCurrentProfile()
             profile.loadProfile(selectedProfileId)
+            tvDetail.text = profileAbout(selectedProfileId)
         }
     }
+
+    private fun profileAbout(profileId: String): String =
+        Prefs.getString("$profileId.$PREF_PROFILE_ABOUT")?.takeIf { it.isNotBlank() }
+            ?: getString(R.string.wizard_step_profile_detail_no_description)
 }

--- a/app/src/main/res/layout/fragment_wizard_profile.xml
+++ b/app/src/main/res/layout/fragment_wizard_profile.xml
@@ -1,25 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/wizard_step_profile_description"
+        android:textColor="?android:attr/textColorSecondary" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/wizard_step_profile_legend"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textSize="12sp" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:background="?android:attr/colorBackground"
+        android:elevation="2dp"
         android:orientation="vertical"
-        android:padding="24dp">
+        android:padding="12dp">
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:text="@string/wizard_step_profile_description"
+            android:text="@string/wizard_step_profile_detail_title"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tvWizardProfileDetail"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
             android:textColor="?android:attr/textColorSecondary" />
+    </LinearLayout>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
         <RadioGroup
             android:id="@+id/rgWizardProfiles"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical" />
-    </LinearLayout>
-</ScrollView>
+    </ScrollView>
+</LinearLayout>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -690,7 +690,10 @@
     <string name="wizard_step_permissions_grant_button">Przyznaj uprawnienia</string>
 
     <string name="wizard_step_profile_title">Profil pojazdu</string>
-    <string name="wizard_step_profile_description">Wybierz profil pojazdu, od którego chcesz zacząć. Możesz to zmienić w dowolnym momencie w Ustawieniach.</string>
+    <string name="wizard_step_profile_description">Profil łączy w sobie ustawienia pojazdu, adaptera, połączenia oraz wybrane PID-y. Przełączenie profilu zmienia całą konfigurację naraz - przydatne, jeśli jeździsz więcej niż jednym samochodem lub używasz różnych adapterów. Wybierz profil, od którego chcesz zacząć; możesz tworzyć, zmieniać nazwy i przełączać profile w dowolnym momencie w Ustawieniach.</string>
+    <string name="wizard_step_profile_legend">Nazwy profili mogą zawierać: BT = Bluetooth, STN = chipy adaptera oparte na STN (OBDSolutions), AA = Android Auto, USB = połączenie USB, WIFI = połączenie WiFi</string>
+    <string name="wizard_step_profile_detail_title">O tym profilu</string>
+    <string name="wizard_step_profile_detail_no_description">Brak opisu dla tego profilu.</string>
 
     <string name="wizard_step_adapter_title">Adapter OBD</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -930,7 +930,10 @@
     <string name="wizard_step_permissions_grant_button">Grant Permissions</string>
 
     <string name="wizard_step_profile_title">Vehicle Profile</string>
-    <string name="wizard_step_profile_description">Pick the vehicle profile you want to start with. You can change this anytime in Preferences.</string>
+    <string name="wizard_step_profile_description">A profile bundles together your vehicle, adapter and connection settings, and PID selections. Switching profiles switches your whole setup at once - handy if you drive more than one car or use different adapters. Pick one to start with; you can create, rename, and switch between profiles anytime in Preferences.</string>
+    <string name="wizard_step_profile_legend">Profile names may include: BT = Bluetooth, STN = STN-based adapter chips (OBDSolutions), AA = Android Auto, USB = USB connectivity, WIFI = WiFi connectivity</string>
+    <string name="wizard_step_profile_detail_title">About This Profile</string>
+    <string name="wizard_step_profile_detail_no_description">No description available for this profile.</string>
 
     <string name="wizard_step_adapter_title">OBD Adapter</string>
 


### PR DESCRIPTION
Profile step now shows each profile's actual profile_N.pref.profile.about text (already authored per-profile in the bundled .properties assets) in a detail panel, instead of a derived adapter/connection-type summary.

The detail panel and a legend explaining the abbreviations used in profile names (BT/STN/AA/USB/WIFI) are now fixed above the profile list, which scrolls independently - previously everything was in one ScrollView, so a long profile list pushed the detail panel out of view.