### PR TITLE
feat(trips): tag trips and publish tags to Google Drive

### DIFF
--- a/app/src/main/assets/2_0_gme_stn_vlinker.properties
+++ b/app/src/main/assets/2_0_gme_stn_vlinker.properties
@@ -110,6 +110,7 @@ profile_20.pref.aa.surface.fps="10"
 profile_20.pref.adapter.reconnect=false
 profile_20.pref.adapter.reconnect.max_retry="3"
 profile_20.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings adjusted to support Vgate Vlinker MS multiplexing capabilities.
+profile_20.pref.profile.tags=2.0gme,bluetooth,stn,vlinker
 
 
 profile_20.pref.giulia.pids.selected=[88008, 88007, 88006, 88005, 88004, 88003, 88002, 88001, 88000]

--- a/app/src/main/assets/alfa_175_tbi.properties
+++ b/app/src/main/assets/alfa_175_tbi.properties
@@ -72,6 +72,7 @@ profile_2.pref.pids.registry.filter_pids_stable=false
 profile_2.pref.adapter.graceful_stop.enabled=false
 profile_2.pref.adapter.responseLength.enabled=true
 profile_2.pref.profile.about=This profile contains Alfa Romeo 1.75 TBI ECU specific settings. It fits cars like Alfa Romeo Giulietta, 4C, 159 as well as Lancia Delta.
+profile_2.pref.profile.tags=175tbi,bluetooth
 
 profile_2.pref.giulia.pids.selected=[6010, 6075, 6012, 6011, 6033, 6003, 6014, 6025, 6013, 6005, 6009, 6008]
 profile_2.pref.giulia.pids.selected.1=[6010, 6075, 6012, 6011, 6033, 6003, 6014, 6025, 6013, 6005, 6009, 6008]

--- a/app/src/main/assets/alfa_175_tbi_stn.properties
+++ b/app/src/main/assets/alfa_175_tbi_stn.properties
@@ -73,6 +73,7 @@ profile_5.pref.adapter.graceful_stop.enabled=false
 profile_5.pref.adapter.responseLength.enabled=true
 profile_5.pref.adapter.stn.enabled=true
 profile_5.pref.profile.about=This profile contains Alfa Romeo 1.75 TBI ECU specific settings. It fits cars like Alfa Romeo Giulietta, 4C, 159 as well as Lancia Delta.
+profile_5.pref.profile.tags=175tbi,bluetooth,stn
 
 profile_5.pref.giulia.pids.selected=[6010, 6075, 6012, 6011, 6033, 6003, 6014, 6025, 6013, 6005, 6009, 6008]
 profile_5.pref.giulia.pids.selected.1=[6010, 6075, 6012, 6011, 6033, 6003, 6014, 6025, 6013, 6005, 6009, 6008]

--- a/app/src/main/assets/alfa_2_0_gme.properties
+++ b/app/src/main/assets/alfa_2_0_gme.properties
@@ -105,6 +105,7 @@ profile_3.pref.aa.surface.fps="10"
 profile_3.pref.adapter.reconnect=false
 profile_3.pref.adapter.reconnect.max_retry="3"
 profile_3.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings. It fits cars like Alfa Romeo Giulia and Stelvio.
+profile_3.pref.profile.tags=2.0gme,bluetooth
 
 
 profile_3.pref.giulia.pids.selected=[7002, 7003, 6, 7005, 7016, 7018]

--- a/app/src/main/assets/alfa_2_0_gme_stn_usb.properties
+++ b/app/src/main/assets/alfa_2_0_gme_stn_usb.properties
@@ -97,6 +97,7 @@ profile_6.pref.adapter.reconnect.max_retry="3"
 profile_6.pref.adapter.stn.enabled=true
 profile_6.pref.adapter.responseLength.enabled=true
 profile_6.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings. It fits cars like Alfa Romeo Giulia and Stelvio. In addition it has enabled settings specified for STNxx based Adapters.
+profile_6.pref.profile.tags=2.0gme,stn,usb
 
 
 profile_6.pref.giulia.pids.selected=[7002, 7003, 6, 7005, 7016, 7018]

--- a/app/src/main/assets/alfa_2_0_gme_stn_wifi.properties
+++ b/app/src/main/assets/alfa_2_0_gme_stn_wifi.properties
@@ -110,6 +110,7 @@ profile_4.pref.adapter.reconnect.max_retry="3"
 profile_4.pref.adapter.stn.enabled=true
 profile_4.pref.adapter.responseLength.enabled=true
 profile_4.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings. It fits cars like Alfa Romeo Giulia and Stelvio. In addition it has enabled settings specified for STNxx based Adapters.
+profile_4.pref.profile.tags=2.0gme,stn,wifi
 
 
 profile_4.pref.giulia.pids.selected=[7002, 7003, 6, 7005, 7016, 7018]

--- a/app/src/main/assets/default.properties
+++ b/app/src/main/assets/default.properties
@@ -62,6 +62,7 @@ profile_1.pref.aa.surface.fps="10"
 profile_1.pref.pids.generic.low=[16, 6]
 profile_1.pref.aa.max_pids_in_column="4"
 profile_1.pref.profile.about=This is default profile. It does not have any specific settings.
+profile_1.pref.profile.tags=default,bluetooth
 
 
 profile_1.pref.giulia.pids.selected=[22, 12, 16, 5, 6, 18]

--- a/app/src/main/assets/default_usb.properties
+++ b/app/src/main/assets/default_usb.properties
@@ -54,7 +54,8 @@ profile_7.pref.pids.registry.list=[mode01_2.json, extra.json, mode01.json]
 profile_7.pref.aa.pids.selected=[22, 12, 16, 5, 6, 18]
 profile_7.pref.pids.generic.low=[16, 6]
 profile_7.pref.aa.max_pids_in_column="4"
-profile_7.pref.profile.about=This is default profile. It USB connection and CAN 11 
+profile_7.pref.profile.about=This is default profile. It USB connection and CAN 11
+profile_7.pref.profile.tags=default,usb
 
 
 profile_7.pref.giulia.pids.selected=[22, 12, 16, 5, 6, 18]

--- a/app/src/main/java/org/obd/graphs/preferences/trips/TripLogListDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/trips/TripLogListDialogFragment.kt
@@ -26,6 +26,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.EditText
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
@@ -41,7 +42,11 @@ import org.obd.graphs.activity.navigateToScreen
 import org.obd.graphs.bl.trip.TripFileDesc
 import org.obd.graphs.bl.trip.tripManager
 import org.obd.graphs.integrations.gcp.gdrive.TripLogDriveManager
+import org.obd.graphs.integrations.gcp.gdrive.TripTags
 import org.obd.graphs.preferences.CoreDialogFragment
+import org.obd.graphs.preferences.Prefs
+import org.obd.graphs.preferences.getString
+import org.obd.graphs.profile.profile
 import org.obd.graphs.registerReceiver
 import org.obd.graphs.sendBroadcastEvent
 import java.io.File
@@ -155,12 +160,18 @@ class TripLogListDialogFragment(
         if (enableUploadCloudButton) {
             uploadToCloud.apply {
                 setOnClickListener {
-                    val builder = AlertDialog.Builder(context)
-                    val title = context.getString(R.string.trip_send_to_cloud_dialog_ask_question)
+                    val dialogView = LayoutInflater.from(context).inflate(R.layout.dialog_trip_upload_tags, null)
+                    val tagsInput = dialogView.findViewById<EditText>(R.id.etUploadTags)
+                    val defaultTags = Prefs.getString("${profile.getCurrentProfile()}.pref.profile.tags")
+                    if (!defaultTags.isNullOrBlank()) {
+                        tagsInput.setText(defaultTags)
+                    }
                     val yes = context.getString(R.string.dialog_ask_question_yes)
                     val no = context.getString(R.string.dialog_ask_question_no)
+
+                    val builder = AlertDialog.Builder(context)
                     builder
-                        .setMessage(title)
+                        .setView(dialogView)
                         .setCancelable(false)
                         .setPositiveButton(yes) { _, _ ->
                             val directory = tripManager.getTripsDirectory(context)
@@ -169,8 +180,10 @@ class TripLogListDialogFragment(
                                 Log.w("TripsListDialogFragment", "User selected no tripe")
                                 sendBroadcastEvent(TRIPS_UPLOAD_NO_FILES_SELECTED)
                             } else {
+                                val tags = TripTags.parse(tagsInput.text.toString())
+
                                 lifecycleScope.launch {
-                                    tripLogDriveManager.uploadTrips(files)
+                                    tripLogDriveManager.uploadTrips(files, tags)
                                 }
                             }
                         }.setNegativeButton(no) { dialog, _ ->

--- a/app/src/main/res/layout/dialog_trip_upload_tags.xml
+++ b/app/src/main/res/layout/dialog_trip_upload_tags.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/trip_send_to_cloud_dialog_ask_question" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:helperTextEnabled="true"
+        app:helperText="@string/trip_upload_tags_helper_text">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etUploadTags"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/trip_upload_tags_hint"
+            android:inputType="text" />
+    </com.google.android.material.textfield.TextInputLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/item_trip.xml
+++ b/app/src/main/res/layout/item_trip.xml
@@ -78,7 +78,8 @@
                 <Button
                     android:id="@+id/trip_load"
                     android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
                     android:gravity="center"
                     android:text="@string/trip_action_load"
                     android:textSize="10sp"
@@ -87,7 +88,8 @@
                 <Button
                     android:id="@+id/trip_delete"
                     android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
+                    android:layout_height="0dp"
+                    android:layout_weight="1"
                     android:backgroundTint="@color/cardinal"
                     android:gravity="center"
                     android:text="@string/trip_action_delete"

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -569,6 +569,8 @@
     <string name="trip_dialog_delete_all_trips">Usuń\nwszystkie</string>
     <string name="trip_delete_dialog_ask_question">Czy na pewno chcesz usunąć?</string>
     <string name="trip_send_to_cloud_dialog_ask_question">Czy na pewno chcesz przesłać wybrane pliki do katalogu giulia/trips na Google Drive?</string>
+    <string name="trip_upload_tags_hint">Tagi (opcjonalnie)</string>
+    <string name="trip_upload_tags_helper_text">Oddzielone przecinkami, np. dojazdy, tor</string>
 
     <string name="dialog_ask_question_yes">Tak</string>
     <string name="dialog_ask_question_no">nie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -577,6 +577,8 @@
     <string name="trip_dialog_delete_all_trips">Delete\nall</string>
     <string name="trip_delete_dialog_ask_question">Are you sure you want to Delete?</string>
     <string name="trip_send_to_cloud_dialog_ask_question">Are you sure you want to upload the selected files to the giulia/trips directory in your Google Drive?</string>
+    <string name="trip_upload_tags_hint">Tags (optional)</string>
+    <string name="trip_upload_tags_helper_text">Comma-separated, e.g. commute, track day</string>
 
     <string name="dialog_ask_question_yes">Yes</string>
     <string name="dialog_ask_question_no">no</string>

--- a/automotive/src/main/assets/alfa_2_0_gme_aa.properties
+++ b/automotive/src/main/assets/alfa_2_0_gme_aa.properties
@@ -121,6 +121,7 @@ profile_8.pref.aa.screen_font_size.4="36"
 profile_8.pref.adapter.reconnect=true
 profile_8.pref.adapter.reconnect.max_retry="3"
 profile_8.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings for Android Auto.\nIt fits cars like Alfa Romeo Giulia and Stelvio.
+profile_8.pref.profile.tags=2.0gme,bluetooth,aa
 
 
 profile_8.pref.giulia.pids.selected=[22, 7035, 13, 7013, 7002, 15, 7014, 7003, 7025, 7006, 7017, 7005, 7027, 7016, 7020, 6, 7019, 7018, 7007, 7029]

--- a/automotive/src/main/assets/alfa_2_0_gme_aa_gg_stn.properties
+++ b/automotive/src/main/assets/alfa_2_0_gme_aa_gg_stn.properties
@@ -131,6 +131,7 @@ profile_10.pref.aa.screen_font_size.4="30"
 profile_10.pref.adapter.reconnect=true
 profile_10.pref.adapter.reconnect.max_retry="3"
 profile_10.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings for Android Auto.\nIt fits cars like Alfa Romeo Giulia and Stelvio.
+profile_10.pref.profile.tags=2.0gme,bluetooth,stn,aa,gg
 
 
 profile_10.pref.giulia.pids.selected=[22, 7035, 13, 7013, 7002, 15, 7014, 7003, 7025, 7006, 7017, 7005, 7027, 7016, 7020, 6, 7019, 7018, 7007, 7029]

--- a/automotive/src/main/assets/alfa_2_0_gme_aa_stn.properties
+++ b/automotive/src/main/assets/alfa_2_0_gme_aa_stn.properties
@@ -126,6 +126,7 @@ profile_9.pref.aa.screen_font_size.4="36"
 profile_9.pref.adapter.reconnect=true
 profile_9.pref.adapter.reconnect.max_retry="3"
 profile_9.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings for Android Auto.\nIt fits cars like Alfa Romeo Giulia and Stelvio.
+profile_9.pref.profile.tags=2.0gme,bluetooth,stn,aa
 
 
 profile_9.pref.giulia.pids.selected=[22, 7035, 13, 7013, 7002, 15, 7014, 7003, 7025, 7006, 7017, 7005, 7027, 7016, 7020, 6, 7019, 7018, 7007, 7029]

--- a/automotive/src/main/assets/alfa_2_0_gme_aa_stn_gpf.properties
+++ b/automotive/src/main/assets/alfa_2_0_gme_aa_stn_gpf.properties
@@ -135,6 +135,7 @@ profile_13.pref.aa.break_label.4=true
 profile_13.pref.adapter.reconnect=true
 profile_13.pref.adapter.reconnect.max_retry="3"
 profile_13.pref.profile.about=This profile contains Alfa Romeo 2.0 GME ECU specific settings for Android Auto.\nIt fits cars like Alfa Romeo Giulia and Stelvio.
+profile_13.pref.profile.tags=2.0gme,bluetooth,stn,gpf
 
 
 profile_13.pref.giulia.pids.selected=[22, 7035, 13, 7013, 7002, 15, 7014, 7003, 7025, 7006, 7017, 7005, 7027, 7016, 7020, 6, 7019, 7018, 7007, 7029]

--- a/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/DriveHelper.kt
+++ b/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/DriveHelper.kt
@@ -61,12 +61,16 @@ internal object DriveHelper {
         localFile: File,
         fileName: String,
         parentFolderId: String,
-        mimeType: String = "text/plain"
+        mimeType: String = "text/plain",
+        appProperties: Map<String, String>? = null
     ): DriveFile {
-        Log.i(TAG, "Uploading file ${localFile.absolutePath} to $fileName")
+        Log.i(TAG, "Uploading file ${localFile.absolutePath} to $fileName appProperties=$appProperties")
         val metadata = DriveFile().apply {
             name = fileName
             parents = listOf(parentFolderId)
+            if (appProperties != null) {
+                this.appProperties = appProperties
+            }
         }
         val content = FileContent(mimeType, localFile)
 

--- a/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/ManualTripLogUpload.kt
+++ b/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/ManualTripLogUpload.kt
@@ -41,41 +41,44 @@ internal open class ManualTripLogUpload(
             sendBroadcastEvent(SCREEN_UNLOCK_PROGRESS_EVENT)
         }
 
-    override suspend fun uploadTrips(files: List<File>) =
-        signInAndExecute("exportTrips") { token ->
-            executeDriveOperation(
-                accessToken = token,
-                onFailure = { sendBroadcastEvent(TRIPS_UPLOAD_FAILED) },
-                onFinally = { sendBroadcastEvent(SCREEN_UNLOCK_PROGRESS_EVENT) }
-            ) { drive ->
-                if (files.isEmpty()) {
-                    sendBroadcastEvent(TRIPS_UPLOAD_NO_FILES_SELECTED)
-                } else {
-                    val folderId = drive.findFolderIdRecursive("mygiulia/trips")
+    override suspend fun uploadTrips(
+        files: List<File>,
+        tags: List<String>
+    ) = signInAndExecute("exportTrips") { token ->
+        executeDriveOperation(
+            accessToken = token,
+            onFailure = { sendBroadcastEvent(TRIPS_UPLOAD_FAILED) },
+            onFinally = { sendBroadcastEvent(SCREEN_UNLOCK_PROGRESS_EVENT) }
+        ) { drive ->
+            if (files.isEmpty()) {
+                sendBroadcastEvent(TRIPS_UPLOAD_NO_FILES_SELECTED)
+            } else {
+                val folderId = drive.findFolderIdRecursive("mygiulia/trips")
 
-                    val transformer = TripUpload.buildTransformer()
-                    val tripDescParser = TripDescParser()
-                    val deviceId = Device.id()
+                val transformer = TripUpload.buildTransformer()
+                val tripDescParser = TripDescParser()
+                val deviceId = Device.id()
 
-                    files.forEach { inFile ->
-                        with(TripUpload) {
-                            drive.transformAndUploadTrip(
-                                inFile = inFile,
-                                cacheDir = activity.cacheDir,
-                                folderId = folderId,
-                                deviceId = deviceId,
-                                transformer = transformer,
-                                tripDescParser = tripDescParser
-                            )
-                        }
-
-                        if (!inFile.path.endsWith(".synced")) {
-                            inFile.renameTo(File(inFile.absolutePath + ".synced"))
-                        }
+                files.forEach { inFile ->
+                    with(TripUpload) {
+                        drive.transformAndUploadTrip(
+                            inFile = inFile,
+                            cacheDir = activity.cacheDir,
+                            folderId = folderId,
+                            deviceId = deviceId,
+                            transformer = transformer,
+                            tripDescParser = tripDescParser,
+                            tags = tags
+                        )
                     }
 
-                    sendBroadcastEvent(TRIPS_UPLOAD_SUCCESSFUL)
+                    if (!inFile.path.endsWith(".synced")) {
+                        inFile.renameTo(File(inFile.absolutePath + ".synced"))
+                    }
                 }
+
+                sendBroadcastEvent(TRIPS_UPLOAD_SUCCESSFUL)
             }
         }
+    }
 }

--- a/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/TripTags.kt
+++ b/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/TripTags.kt
@@ -16,22 +16,10 @@
  */
 package org.obd.graphs.integrations.gcp.gdrive
 
-import android.app.Activity
-import androidx.fragment.app.Fragment
-import java.io.File
+// Shared by the upload path (TripUpload, writing Drive appProperties) and the upload dialog's
+// tag input (TripLogListDialogFragment) - one place for the comma-separated tag convention.
+object TripTags {
+    fun parse(raw: String?): List<String> = raw?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
 
-interface TripLogDriveManager {
-    suspend fun uploadTrips(
-        files: List<File>,
-        tags: List<String> = emptyList()
-    )
-
-    suspend fun authenticate()
-    companion object {
-        fun instance(
-            webClientId: String,
-            activity: Activity,
-            fragment: Fragment?
-        ): TripLogDriveManager = ManualTripLogUpload(webClientId, activity, fragment)
-    }
+    fun format(tags: List<String>): String = tags.joinToString(",")
 }

--- a/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/TripUpload.kt
+++ b/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/TripUpload.kt
@@ -48,6 +48,17 @@ internal object TripUpload {
     }
 
     /**
+     * The Drive file name a local trip file is uploaded under.
+     */
+    fun driveTripFileName(
+        deviceId: String,
+        localFileName: String
+    ): String {
+        val originalName = localFileName.removePrefix("trip-profile_")
+        return "$deviceId-$originalName.json.gz"
+    }
+
+    /**
      * Transforms, compresses, and uploads a single trip file to Google Drive.
      */
     fun Drive.transformAndUploadTrip(
@@ -56,7 +67,8 @@ internal object TripUpload {
         folderId: String,
         deviceId: String,
         transformer: TripLogTransformer,
-        tripDescParser: TripDescParser
+        tripDescParser: TripDescParser,
+        tags: List<String> = emptyList()
     ) {
         val metadata = mutableMapOf<String, String>()
         val tripDesc = tripDescParser.getTripDesc(inFile.name)
@@ -76,9 +88,9 @@ internal object TripUpload {
             }
         }
 
-        val originalName = inFile.name.removePrefix("trip-profile_")
-        val fileName = "$deviceId-$originalName.json.gz"
-        this.uploadFile(tempGzipFile, fileName, folderId, "application/gzip")
+        val fileName = driveTripFileName(deviceId, inFile.name)
+        val appProperties = if (tags.isNotEmpty()) mapOf("tags" to TripTags.format(tags)) else null
+        this.uploadFile(tempGzipFile, fileName, folderId, "application/gzip", appProperties)
 
         tempGzipFile.delete()
         transformedFile.delete()

--- a/integrations/src/test/java/org/obd/graphs/integrations/gcp/gdrive/GDriveTestSuite.kt
+++ b/integrations/src/test/java/org/obd/graphs/integrations/gcp/gdrive/GDriveTestSuite.kt
@@ -23,6 +23,8 @@ import org.junit.runners.Suite.SuiteClasses
 @RunWith(Suite::class)
 @SuiteClasses(
     TripLogTransformerTest::class,
-    TripLogDriveManagerTest::class
+    TripLogDriveManagerTest::class,
+    TripTagsTest::class,
+    TripUploadTest::class
 )
 class GDriveTestSuite

--- a/integrations/src/test/java/org/obd/graphs/integrations/gcp/gdrive/TripTagsTest.kt
+++ b/integrations/src/test/java/org/obd/graphs/integrations/gcp/gdrive/TripTagsTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.integrations.gcp.gdrive
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TripTagsTest {
+
+    @Test
+    fun `parse returns empty list for null input`() {
+        assertTrue(TripTags.parse(null).isEmpty())
+    }
+
+    @Test
+    fun `parse returns empty list for blank input`() {
+        assertTrue(TripTags.parse("").isEmpty())
+        assertTrue(TripTags.parse("   ").isEmpty())
+    }
+
+    @Test
+    fun `parse splits comma-separated tags and trims whitespace`() {
+        assertEquals(listOf("commute", "morning"), TripTags.parse("commute, morning"))
+        assertEquals(listOf("track day"), TripTags.parse("  track day  "))
+    }
+
+    @Test
+    fun `parse drops empty entries from stray commas`() {
+        assertEquals(listOf("commute", "morning"), TripTags.parse("commute,,morning,"))
+        assertEquals(listOf("commute"), TripTags.parse(",commute,"))
+    }
+
+    @Test
+    fun `format joins tags with a comma and no spaces`() {
+        assertEquals("commute,morning", TripTags.format(listOf("commute", "morning")))
+        assertEquals("track day", TripTags.format(listOf("track day")))
+        assertEquals("", TripTags.format(emptyList()))
+    }
+
+    @Test
+    fun `format then parse round-trips to the same tags`() {
+        val tags = listOf("2.0gme", "bluetooth", "stn")
+        assertEquals(tags, TripTags.parse(TripTags.format(tags)))
+    }
+}

--- a/integrations/src/test/java/org/obd/graphs/integrations/gcp/gdrive/TripUploadTest.kt
+++ b/integrations/src/test/java/org/obd/graphs/integrations/gcp/gdrive/TripUploadTest.kt
@@ -16,22 +16,24 @@
  */
 package org.obd.graphs.integrations.gcp.gdrive
 
-import android.app.Activity
-import androidx.fragment.app.Fragment
-import java.io.File
+import org.junit.Test
+import kotlin.test.assertEquals
 
-interface TripLogDriveManager {
-    suspend fun uploadTrips(
-        files: List<File>,
-        tags: List<String> = emptyList()
-    )
+class TripUploadTest {
 
-    suspend fun authenticate()
-    companion object {
-        fun instance(
-            webClientId: String,
-            activity: Activity,
-            fragment: Fragment?
-        ): TripLogDriveManager = ManualTripLogUpload(webClientId, activity, fragment)
+    @Test
+    fun `driveTripFileName strips the trip-profile_ prefix and appends json gz`() {
+        assertEquals(
+            "device123-1-1234567890-120.jsonl.json.gz",
+            TripUpload.driveTripFileName("device123", "trip-profile_1-1234567890-120.jsonl")
+        )
+    }
+
+    @Test
+    fun `driveTripFileName leaves the name untouched if the prefix is absent`() {
+        assertEquals(
+            "device123-some-other-name.json.gz",
+            TripUpload.driveTripFileName("device123", "some-other-name")
+        )
     }
 }


### PR DESCRIPTION
Adds a tag input to the trip upload dialog, prefilled from the active profile's pref.profile.tags default, and writes tags into the uploaded trip's Drive file appProperties at upload time (no separate tags file, local or remote). Also fixes a layout bug where trip_load/trip_delete buttons had undefined height distribution without layout_weight.