### PR TITLE
feat(trips): show detailed, copyable error dialog on upload failure

### DIFF
--- a/app/src/main/java/org/obd/graphs/activity/Receivers.kt
+++ b/app/src/main/java/org/obd/graphs/activity/Receivers.kt
@@ -98,6 +98,7 @@ import org.obd.graphs.registerReceiver
 import org.obd.graphs.sendBroadcastEvent
 import org.obd.graphs.ui.common.COLOR_CARDINAL
 import org.obd.graphs.ui.common.COLOR_PHILIPPINE_GREEN
+import org.obd.graphs.ui.common.showCopyableErrorDialog
 import org.obd.graphs.ui.common.toast
 import org.obd.graphs.ui.withDataLogger
 
@@ -132,7 +133,14 @@ internal fun MainActivity.receive(intent: Intent?) {
         NAVIGATION_BUTTONS_VISIBILITY_CHANGED -> setupNavigationBar()
         GOOGLE_SIGN_IN_NO_CREDENTIAL_FAILURE -> toast(org.obd.graphs.commons.R.string.main_activity_toast_google_signin_failed)
         GOOGLE_SIGN_IN_GENERAL_FAILURE -> toast(org.obd.graphs.commons.R.string.main_activity_toast_google_signin_failed_restart)
-        TRIPS_UPLOAD_FAILED -> toast(org.obd.graphs.commons.R.string.main_activity_toast_trips_upload_failed)
+        TRIPS_UPLOAD_FAILED -> {
+            val detail = intent.getSerializableCompat<String>() ?: ""
+            showCopyableErrorDialog(
+                title = getString(org.obd.graphs.commons.R.string.main_activity_dialog_trips_upload_failed_title),
+                message = getString(org.obd.graphs.commons.R.string.main_activity_toast_trips_upload_failed, detail),
+                clipLabel = "Trip upload error"
+            )
+        }
         TRIPS_UPLOAD_SUCCESSFUL -> toast(org.obd.graphs.commons.R.string.main_activity_toast_trips_upload_successful)
         TRIPS_UPLOAD_NO_FILES_SELECTED -> toast(org.obd.graphs.commons.R.string.main_activity_toast_trips_upload_no_files_selected)
 

--- a/app/src/main/java/org/obd/graphs/ui/common/ErrorDialog.kt
+++ b/app/src/main/java/org/obd/graphs/ui/common/ErrorDialog.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.ui.common
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
+import org.obd.graphs.R
+
+/**
+ * A dialog for failures the user may need to relay back verbatim (API error details,
+ * exception messages) - a toast auto-dismisses too fast to read/copy for these.
+ */
+fun Context.showCopyableErrorDialog(
+    title: String,
+    message: String,
+    clipLabel: String = "Error details"
+) {
+    AlertDialog.Builder(this)
+        .setTitle(title)
+        .setMessage(message)
+        .setCancelable(true)
+        .setPositiveButton(R.string.dtc_action_copy) { dialog, _ ->
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText(clipLabel, message))
+            Toast.makeText(this, R.string.error_dialog_copied_to_clipboard, Toast.LENGTH_SHORT).show()
+            dialog.dismiss()
+        }.setNegativeButton(R.string.nav_close) { dialog, _ -> dialog.dismiss() }
+        .show()
+}
+
+fun Context.showCopyableErrorDialog(
+    @StringRes titleRes: Int,
+    message: String,
+    clipLabel: String = "Error details"
+) = showCopyableErrorDialog(getString(titleRes), message, clipLabel)

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -643,6 +643,7 @@
     <string name="dtc.action_refresh">Odśwież</string>
     <string name="dtc.action_clear_codes">Skasuj kody</string>
     <string name="dtc.action_share">Udostępnij</string>
+    <string name="error_dialog.copied_to_clipboard">Skopiowano do schowka</string>
     <string name="dialog.screen_lock.cancel">Anuluj</string>
     <string name="gps.title">DIAGNOSTYKA GPS</string>
     <string name="gps.status_label">Status</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -865,6 +865,7 @@
     <string name="dtc.action_refresh">Refresh</string>
     <string name="dtc.action_clear_codes">Clear Codes</string>
     <string name="dtc.action_share">Share</string>
+    <string name="error_dialog.copied_to_clipboard">Copied to clipboard</string>
     <string name="dialog.screen_lock.cancel">Cancel</string>
     <string name="gps.title">GPS DIAGNOSTICS</string>
     <string name="gps.status_label">Status</string>

--- a/common/src/main/res/values-pl/strings.xml
+++ b/common/src/main/res/values-pl/strings.xml
@@ -25,7 +25,8 @@
     <string name="main_activity.toast.custom_pids.download.successful">Własne PID-y zostały pobrane z Dysku Google.</string>
     <string name="main_activity.toast.custom_pids.download.no_files">Na Dysku Google nie znaleziono pliku z własnymi PID-ami.</string>
 
-    <string name="main_activity.toast.trips.upload.failed">Wysyłanie tras nie powiodło się.</string>
+    <string name="main_activity.toast.trips.upload.failed">Wysyłanie tras nie powiodło się. %1$s</string>
+    <string name="main_activity.dialog.trips_upload_failed.title">Przesyłanie trasy nie powiodło się</string>
     <string name="main_activity.toast.trips.upload.successful">Wysyłanie tras zakończone pomyślnie.</string>
     <string name="main_activity.toast.trips.upload.no_files_selected">Nie wybrano plików. Nic nie zostało wysłane.</string>
     <string name="main_activity.toast.google.signin.failed_restart">Logowanie Google obecnie nie działa. Uruchom ponownie aplikację.</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -25,7 +25,8 @@
     <string name="main_activity.toast.custom_pids.download.successful">Custom PIDs downloaded from Google Drive successfully.</string>
     <string name="main_activity.toast.custom_pids.download.no_files">There is no custom PIDs file available in Google Drive.</string>
 
-    <string name="main_activity.toast.trips.upload.failed">Trips upload operation failed. </string>
+    <string name="main_activity.toast.trips.upload.failed">Trips upload operation failed. %1$s</string>
+    <string name="main_activity.dialog.trips_upload_failed.title">Trip Upload Failed</string>
     <string name="main_activity.toast.trips.upload.successful">Trips upload operation completed successfully.</string>
     <string name="main_activity.toast.trips.upload.no_files_selected">There is no files selected. Nothing was uploaded.</string>
     <string name="main_activity.toast.google.signin.failed_restart">Google sign-in isn"t working at the moment. Please restart application.</string>

--- a/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/AbstractDriveManager.kt
+++ b/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/AbstractDriveManager.kt
@@ -67,7 +67,7 @@ internal abstract class AbstractDriveManager(
      */
     open suspend fun <T> executeDriveOperation(
         accessToken: String,
-        onFailure: () -> Unit,
+        onFailure: (message: String) -> Unit,
         onFinally: () -> Unit,
         block: suspend (Drive) -> T
     ) {
@@ -91,14 +91,14 @@ internal abstract class AbstractDriveManager(
                     } catch (clearEx: Exception) {
                         Log.e(TAG, "Failed to invalidate token", clearEx)
                     }
-                    onFailure()
+                    onFailure("Session expired (401). Please sign in again.")
                 } else {
                     Log.e(TAG, "Drive API error: ${e.statusCode}", e)
-                    onFailure()
+                    onFailure("Google Drive error ${e.statusCode}: ${e.details?.message ?: e.message}")
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "General Drive error", e)
-                onFailure()
+                onFailure(e.message ?: e.javaClass.simpleName)
             } finally {
                 onFinally()
             }

--- a/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/ManualTripLogUpload.kt
+++ b/integrations/src/main/java/org/obd/graphs.integrations/gcp/gdrive/ManualTripLogUpload.kt
@@ -47,7 +47,7 @@ internal open class ManualTripLogUpload(
     ) = signInAndExecute("exportTrips") { token ->
         executeDriveOperation(
             accessToken = token,
-            onFailure = { sendBroadcastEvent(TRIPS_UPLOAD_FAILED) },
+            onFailure = { message -> sendBroadcastEvent(TRIPS_UPLOAD_FAILED, message) },
             onFinally = { sendBroadcastEvent(SCREEN_UNLOCK_PROGRESS_EVENT) }
         ) { drive ->
             if (files.isEmpty()) {


### PR DESCRIPTION
Trip upload failures only showed a generic toast with no detail, making user-reported failures hard to diagnose. Drive API errors, auth failures, and general exceptions now carry a real message through to a dialog the user can copy and send back, via a new reusable showCopyableErrorDialog component.