### PR TITLE
feat(pids): make PID drag-and-drop order affect Dashboard/Graph/Gauge…

### DIFF
--- a/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
@@ -99,7 +99,8 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     "dash" -> {
                         openPIDsDialog(
                             "pref.dash.pids.selected",
-                            PREFERENCE_SCREEN_SOURCE_DASHBOARD
+                            PREFERENCE_SCREEN_SOURCE_DASHBOARD,
+                            orderPrefKey = "prefs.dash.pids.settings"
                         ) { navigateToScreen(R.id.nav_dashboard) }
                     }
 
@@ -304,7 +305,11 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                 ) { navigateToScreen(R.id.nav_performance) }
 
             PREFERENCE_SCREEN_KEY_DASH ->
-                openPIDsDialog("pref.dash.pids.selected", PREFERENCE_SCREEN_SOURCE_DASHBOARD) { navigateToScreen(R.id.nav_dashboard) }
+                openPIDsDialog(
+                    "pref.dash.pids.selected",
+                    PREFERENCE_SCREEN_SOURCE_DASHBOARD,
+                    orderPrefKey = "prefs.dash.pids.settings"
+                ) { navigateToScreen(R.id.nav_dashboard) }
 
             PREFERENCE_SCREEN_KEY_GAUGE ->
                 openPIDsDialog(
@@ -328,11 +333,13 @@ class PreferencesFragment : PreferenceFragmentCompat() {
     private fun openPIDsDialog(
         key: String,
         source: String,
+        orderPrefKey: String? = null,
         onDialogCloseListener: (() -> Unit) = {}
     ) {
         PidDefinitionDialogFragment(
             key = key,
             source = source,
+            orderPrefKey = orderPrefKey,
             onDialogCloseListener = onDialogCloseListener
         ).show(parentFragmentManager, null)
     }

--- a/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/PreferencesFragment.kt
@@ -107,21 +107,24 @@ class PreferencesFragment : PreferenceFragmentCompat() {
                     PREFERENCE_SCREEN_SOURCE_GRAPH -> {
                         openPIDsDialog(
                             tripVirtualScreenManager.getVirtualScreenPrefKey(),
-                            preference.source
+                            preference.source,
+                            dragReorderEnabled = Prefs.isEnabled("pref.pids.custom_order.enabled")
                         ) { navigateToScreen(R.id.nav_graph) }
                     }
 
                     PREFERENCE_SCREEN_SOURCE_GIULIA -> {
                         openPIDsDialog(
                             giuliaVirtualScreenPreferences.getVirtualScreenPrefKey(),
-                            preference.source
+                            preference.source,
+                            dragReorderEnabled = Prefs.isEnabled("pref.pids.custom_order.enabled")
                         ) { navigateToScreen(R.id.nav_giulia) }
                     }
 
                     PREFERENCE_SCREEN_SOURCE_GAUGE -> {
                         openPIDsDialog(
                             gaugeVirtualScreenPreferences.getVirtualScreenPrefKey(),
-                            preference.source
+                            preference.source,
+                            dragReorderEnabled = Prefs.isEnabled("pref.pids.custom_order.enabled")
                         ) { navigateToScreen(R.id.nav_gauge) }
                     }
 
@@ -314,18 +317,24 @@ class PreferencesFragment : PreferenceFragmentCompat() {
             PREFERENCE_SCREEN_KEY_GAUGE ->
                 openPIDsDialog(
                     gaugeVirtualScreenPreferences.getVirtualScreenPrefKey(),
-                    PREFERENCE_SCREEN_SOURCE_GAUGE
+                    PREFERENCE_SCREEN_SOURCE_GAUGE,
+                    dragReorderEnabled = Prefs.isEnabled("pref.pids.custom_order.enabled")
                 ) { navigateToScreen(R.id.nav_gauge) }
 
             PREFERENCE_SCREEN_KEY_GIULIA ->
-                openPIDsDialog(giuliaVirtualScreenPreferences.getVirtualScreenPrefKey(), PREFERENCE_SCREEN_SOURCE_GIULIA) {
+                openPIDsDialog(
+                    giuliaVirtualScreenPreferences.getVirtualScreenPrefKey(),
+                    PREFERENCE_SCREEN_SOURCE_GIULIA,
+                    dragReorderEnabled = Prefs.isEnabled("pref.pids.custom_order.enabled")
+                ) {
                     navigateToScreen(R.id.nav_giulia)
                 }
 
             PREFERENCE_SCREEN_KEY_GRAPH ->
                 openPIDsDialog(
                     tripVirtualScreenManager.getVirtualScreenPrefKey(),
-                    PREFERENCE_SCREEN_SOURCE_GRAPH
+                    PREFERENCE_SCREEN_SOURCE_GRAPH,
+                    dragReorderEnabled = Prefs.isEnabled("pref.pids.custom_order.enabled")
                 ) { navigateToScreen(R.id.nav_graph) }
         }
     }
@@ -334,12 +343,14 @@ class PreferencesFragment : PreferenceFragmentCompat() {
         key: String,
         source: String,
         orderPrefKey: String? = null,
+        dragReorderEnabled: Boolean = true,
         onDialogCloseListener: (() -> Unit) = {}
     ) {
         PidDefinitionDialogFragment(
             key = key,
             source = source,
             orderPrefKey = orderPrefKey,
+            dragReorderEnabled = dragReorderEnabled,
             onDialogCloseListener = onDialogCloseListener
         ).show(parentFragmentManager, null)
     }

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -46,6 +46,7 @@ open class PidDefinitionDialogFragment(
     private val key: String,
     source: String,
     private val orderPrefKey: String? = null,
+    private val dragReorderEnabled: Boolean = true,
     private val onDialogCloseListener: (() -> Unit) = {}
 ) : CoreDialogFragment() {
 
@@ -83,7 +84,9 @@ open class PidDefinitionDialogFragment(
         recyclerView.adapter = adapter
 
         attachSearchView()
-        attachDragManager(recyclerView)
+        if (dragReorderEnabled) {
+            attachDragManager(recyclerView)
+        }
         attachActionButtons()
 
         val fabAddPid = root.findViewById<View>(R.id.fab_add_pid)

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -45,6 +45,7 @@ import org.obd.metrics.pid.PidDefinition
 open class PidDefinitionDialogFragment(
     private val key: String,
     source: String,
+    private val orderPrefKey: String? = null,
     private val onDialogCloseListener: (() -> Unit) = {}
 ) : CoreDialogFragment() {
 
@@ -53,7 +54,7 @@ open class PidDefinitionDialogFragment(
 
     private val dialogMode: PidDefinitionDialogMode = PidDefinitionDialogMode.fromString(source)
     private val viewModel: PidDefinitionViewModel by viewModels {
-        PidViewModelFactory(key, dialogMode, CustomPidRepository(requireContext().applicationContext))
+        PidViewModelFactory(key, dialogMode, CustomPidRepository(requireContext().applicationContext), orderPrefKey)
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewModel.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewModel.kt
@@ -65,7 +65,8 @@ data class PidUiState(
 class PidDefinitionViewModel(
     private val key: String,
     val dialogMode: PidDefinitionDialogMode,
-    private val customPidRepository: CustomPidRepository
+    private val customPidRepository: CustomPidRepository,
+    private val orderPrefKey: String? = null
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PidUiState())
@@ -285,7 +286,7 @@ class PidDefinitionViewModel(
         return (userPids + checkedStandard + uncheckedStandard).toMutableList()
     }
 
-    private fun viewPreferencesSerializer(): ViewPreferencesSerializer = ViewPreferencesSerializer("$key.view.settings")
+    private fun viewPreferencesSerializer(): ViewPreferencesSerializer = ViewPreferencesSerializer(orderPrefKey ?: "$key.view.settings")
 
     private fun map(all: MutableCollection<PidDefinition>): List<PidDefinitionDetails> {
         val source = Prefs.getStringSet(HIGH_PRIO_PID_PREF).map { s -> s.toLong() } +
@@ -324,12 +325,13 @@ class PidDefinitionViewModel(
 class PidViewModelFactory(
     private val key: String,
     private val dialogMode: PidDefinitionDialogMode,
-    private val customPidRepository: CustomPidRepository
+    private val customPidRepository: CustomPidRepository,
+    private val orderPrefKey: String? = null
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(PidDefinitionViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return PidDefinitionViewModel(key, dialogMode, customPidRepository) as T
+            return PidDefinitionViewModel(key, dialogMode, customPidRepository, orderPrefKey) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/org/obd/graphs/ui/gauge/GaugeSettings.kt
+++ b/app/src/main/java/org/obd/graphs/ui/gauge/GaugeSettings.kt
@@ -16,6 +16,7 @@
  */
 package org.obd.graphs.ui.gauge
 
+import org.obd.graphs.ViewPreferencesSerializer
 import org.obd.graphs.preferences.Prefs
 import org.obd.graphs.preferences.getS
 import org.obd.graphs.preferences.getStringSet
@@ -30,6 +31,10 @@ class GaugeSettings : ScreenSettings {
             override fun getFontSize(): Int = Prefs.getS("pref.gauge.font_size", "42").toInt()
 
             override fun getGaugeContainerColor(): Int = Prefs.getInt("pref.gauge_background_color", COLOR_RAINBOW_INDIGO)
+
+            override fun getPIDsSortOrder(): Map<Long, Int>? =
+                ViewPreferencesSerializer("${gaugeVirtualScreenPreferences.getVirtualScreenPrefKey()}.view.settings")
+                    .getItemsSortOrder()
         }
 
     override fun getGaugeScreenSettings(): GaugeScreenSettings =

--- a/app/src/main/java/org/obd/graphs/ui/gauge/GaugeSettings.kt
+++ b/app/src/main/java/org/obd/graphs/ui/gauge/GaugeSettings.kt
@@ -32,9 +32,15 @@ class GaugeSettings : ScreenSettings {
 
             override fun getGaugeContainerColor(): Int = Prefs.getInt("pref.gauge_background_color", COLOR_RAINBOW_INDIGO)
 
+            override fun isPIDsSortOrderEnabled(): Boolean = Prefs.isEnabled("pref.pids.custom_order.enabled")
+
             override fun getPIDsSortOrder(): Map<Long, Int>? =
-                ViewPreferencesSerializer("${gaugeVirtualScreenPreferences.getVirtualScreenPrefKey()}.view.settings")
-                    .getItemsSortOrder()
+                if (isPIDsSortOrderEnabled()) {
+                    ViewPreferencesSerializer("${gaugeVirtualScreenPreferences.getVirtualScreenPrefKey()}.view.settings")
+                        .getItemsSortOrder()
+                } else {
+                    null
+                }
         }
 
     override fun getGaugeScreenSettings(): GaugeScreenSettings =

--- a/app/src/main/java/org/obd/graphs/ui/giulia/GiuliaSettings.kt
+++ b/app/src/main/java/org/obd/graphs/ui/giulia/GiuliaSettings.kt
@@ -16,6 +16,7 @@
  */
 package org.obd.graphs.ui.giulia
 
+import org.obd.graphs.ViewPreferencesSerializer
 import org.obd.graphs.preferences.Prefs
 import org.obd.graphs.preferences.getS
 import org.obd.graphs.preferences.getStringSet
@@ -28,6 +29,10 @@ class GiuliaSettings : ScreenSettings {
     private val giuliaScreenSettings =
         object : GiuliaScreenSettings() {
             override fun getFontSize(): Int = giuliaVirtualScreenPreferences.getFontSize()
+
+            override fun getPIDsSortOrder(): Map<Long, Int>? =
+                ViewPreferencesSerializer("${giuliaVirtualScreenPreferences.getVirtualScreenPrefKey()}.view.settings")
+                    .getItemsSortOrder()
         }
 
     override fun getGiuliaScreenSettings(): GiuliaScreenSettings = giuliaScreenSettings.apply {

--- a/app/src/main/java/org/obd/graphs/ui/giulia/GiuliaSettings.kt
+++ b/app/src/main/java/org/obd/graphs/ui/giulia/GiuliaSettings.kt
@@ -20,6 +20,7 @@ import org.obd.graphs.ViewPreferencesSerializer
 import org.obd.graphs.preferences.Prefs
 import org.obd.graphs.preferences.getS
 import org.obd.graphs.preferences.getStringSet
+import org.obd.graphs.preferences.isEnabled
 import org.obd.graphs.renderer.api.GiuliaScreenSettings
 import org.obd.graphs.renderer.api.ScreenSettings
 
@@ -30,9 +31,15 @@ class GiuliaSettings : ScreenSettings {
         object : GiuliaScreenSettings() {
             override fun getFontSize(): Int = giuliaVirtualScreenPreferences.getFontSize()
 
+            override fun isPIDsSortOrderEnabled(): Boolean = Prefs.isEnabled("pref.pids.custom_order.enabled")
+
             override fun getPIDsSortOrder(): Map<Long, Int>? =
-                ViewPreferencesSerializer("${giuliaVirtualScreenPreferences.getVirtualScreenPrefKey()}.view.settings")
-                    .getItemsSortOrder()
+                if (isPIDsSortOrderEnabled()) {
+                    ViewPreferencesSerializer("${giuliaVirtualScreenPreferences.getVirtualScreenPrefKey()}.view.settings")
+                        .getItemsSortOrder()
+                } else {
+                    null
+                }
         }
 
     override fun getGiuliaScreenSettings(): GiuliaScreenSettings = giuliaScreenSettings.apply {

--- a/app/src/main/java/org/obd/graphs/ui/graph/GraphPreferences.kt
+++ b/app/src/main/java/org/obd/graphs/ui/graph/GraphPreferences.kt
@@ -17,6 +17,7 @@
 package org.obd.graphs.ui.graph
 
 import android.util.Log
+import org.obd.graphs.ViewPreferencesSerializer
 import org.obd.graphs.bl.trip.tripVirtualScreenManager
 import org.obd.graphs.preferences.Prefs
 import org.obd.graphs.preferences.getS
@@ -43,7 +44,21 @@ class GraphPreferencesReader {
 
         val cacheEnabled = Prefs.getBoolean("$prefixKey.cache.enabled", true)
 
-        val metrics = tripVirtualScreenManager.getCurrentMetrics().map { it.toLong() }.toSet()
+        val sortOrder =
+            ViewPreferencesSerializer("${tripVirtualScreenManager.getVirtualScreenPrefKey()}.view.settings")
+                .getItemsSortOrder()
+
+        // Prefs.getStringSet() is an unordered HashSet under the hood, so the ids need an explicit
+        // sort here - .toSet() below preserves this order (LinkedHashSet), unlike the source set.
+        val metrics =
+            tripVirtualScreenManager.getCurrentMetrics().map { it.toLong() }
+                .sortedWith { id1, id2 ->
+                    if (sortOrder != null && sortOrder.containsKey(id1) && sortOrder.containsKey(id2)) {
+                        sortOrder[id1]!!.compareTo(sortOrder[id2]!!)
+                    } else {
+                        id1.compareTo(id2)
+                    }
+                }.toSet()
 
         val toggleVirtualPanel = Prefs.getBoolean("$prefixKey.toggle_virtual_screens_double_click", true)
 

--- a/app/src/main/java/org/obd/graphs/ui/graph/GraphPreferences.kt
+++ b/app/src/main/java/org/obd/graphs/ui/graph/GraphPreferences.kt
@@ -21,6 +21,7 @@ import org.obd.graphs.ViewPreferencesSerializer
 import org.obd.graphs.bl.trip.tripVirtualScreenManager
 import org.obd.graphs.preferences.Prefs
 import org.obd.graphs.preferences.getS
+import org.obd.graphs.preferences.isEnabled
 
 data class GraphPreferences(
     val xAxisStartMovingAfter: Float,
@@ -45,8 +46,12 @@ class GraphPreferencesReader {
         val cacheEnabled = Prefs.getBoolean("$prefixKey.cache.enabled", true)
 
         val sortOrder =
-            ViewPreferencesSerializer("${tripVirtualScreenManager.getVirtualScreenPrefKey()}.view.settings")
-                .getItemsSortOrder()
+            if (Prefs.isEnabled("pref.pids.custom_order.enabled")) {
+                ViewPreferencesSerializer("${tripVirtualScreenManager.getVirtualScreenPrefKey()}.view.settings")
+                    .getItemsSortOrder()
+            } else {
+                null
+            }
 
         // Prefs.getStringSet() is an unordered HashSet under the hood, so the ids need an explicit
         // sort here - .toSet() below preserves this order (LinkedHashSet), unlike the source set.

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -292,6 +292,8 @@
     <string name="pref.aa.connect_dialog.enabled">Wyświetl okno dialogowe połączenia podczas nawiązywania połączenia z adapterem OBD2</string>
     <string name="pref.aa.virtual_screens.sort_order.enabled">Włącz sortowanie PID</string>
     <string name="pref.aa.virtual_screens.sort_order.enabled_summary">To jest funkcja EKSPERYMENTALNA.\nPozwala zdefiniować kolejność PID na ekranie za pomocą przeciągania i upuszczania na liście wyboru PID. Po włączeniu tej opcji wymagane jest ponowne uruchomienie aplikacji.</string>
+    <string name="pref.pids.custom_order.enabled">Włącz niestandardową kolejność PID</string>
+    <string name="pref.pids.custom_order.enabled_summary">To jest funkcja EKSPERYMENTALNA.\nStosuje kolejność ustawioną poprzez przeciąganie i upuszczanie PID na liście wyboru PID do ekranów Dashboard, Wykres, Zegary i Giulia.</string>
 
     <string name="pref.aa.title">Android Auto</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,6 +288,8 @@
     <string name="pref.aa.connect_dialog.enabled">Display the connection dialog while establishing a connection with the OBD2 adapter</string>
     <string name="pref.aa.virtual_screens.sort_order.enabled">Enable PIDs sort order</string>
     <string name="pref.aa.virtual_screens.sort_order.enabled_summary">This is an EXPERIMENTAL feature.\nIt allows you to define the order of PIDs on the screen using drag-and-drop within the PID selection list. An app restart is required after enabling this option.</string>
+    <string name="pref.pids.custom_order.enabled">Enable custom PID order</string>
+    <string name="pref.pids.custom_order.enabled_summary">This is an EXPERIMENTAL feature.\nApplies the order you set by dragging and dropping PIDs in the PID selection list to the Dashboard, Graph, Gauge, and Giulia screens.</string>
 
     <string name="pref.aa.title">Android Auto</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -123,6 +123,14 @@
                     app:experimental="true"
                     app:singleLineTitle="false" />
 
+                <org.obd.graphs.preferences.components.ExtendedCheckBoxPreference
+                    android:defaultValue="false"
+                    android:key="pref.pids.custom_order.enabled"
+                    android:summary="@string/pref.pids.custom_order.enabled_summary"
+                    android:title="@string/pref.pids.custom_order.enabled"
+                    app:experimental="true"
+                    app:singleLineTitle="false" />
+
             </PreferenceCategory>
 
             <PreferenceCategory android:title="@string/pref.pid.custom.category">


### PR DESCRIPTION
…/Giulia

The reorder UI already existed in the PID selection dialog but had no effect on the actual screens: Dashboard's dialog wrote to a different preference key than the dashboard reader used, Gauge/Giulia had a working order parameter wired to a hardcoded empty map, and Graph never read stored order at all. Wires the reader side in all four places to the order the dialog already persists.