### PR TITLE
feat(shortcuts): add launcher app shortcuts for Graph, Gauges, and Trips

### DIFF
--- a/app/src/giulia/res/xml/shortcuts.xml
+++ b/app/src/giulia/res/xml/shortcuts.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut
+        android:shortcutId="graph"
+        android:enabled="true"
+        android:icon="@drawable/ic_graph"
+        android:shortcutShortLabel="@string/shortcut.graph.short_label"
+        android:shortcutLongLabel="@string/shortcut.graph.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="graph" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="gauge"
+        android:enabled="true"
+        android:icon="@drawable/ic_gauge"
+        android:shortcutShortLabel="@string/shortcut.gauge.short_label"
+        android:shortcutLongLabel="@string/shortcut.gauge.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="gauge" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="trip_logs"
+        android:enabled="true"
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutShortLabel="@string/shortcut.trip_logs.short_label"
+        android:shortcutLongLabel="@string/shortcut.trip_logs.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="trip_logs" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="trip_upload"
+        android:enabled="true"
+        android:icon="@drawable/ic_action_execute"
+        android:shortcutShortLabel="@string/shortcut.trip_upload.short_label"
+        android:shortcutLongLabel="@string/shortcut.trip_upload.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="trip_upload" />
+        </intent>
+    </shortcut>
+
+</shortcuts>

--- a/app/src/giuliaAA/res/xml/shortcuts.xml
+++ b/app/src/giuliaAA/res/xml/shortcuts.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut
+        android:shortcutId="graph"
+        android:enabled="true"
+        android:icon="@drawable/ic_graph"
+        android:shortcutShortLabel="@string/shortcut.graph.short_label"
+        android:shortcutLongLabel="@string/shortcut.graph.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.aa"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="graph" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="gauge"
+        android:enabled="true"
+        android:icon="@drawable/ic_gauge"
+        android:shortcutShortLabel="@string/shortcut.gauge.short_label"
+        android:shortcutLongLabel="@string/shortcut.gauge.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.aa"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="gauge" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="trip_logs"
+        android:enabled="true"
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutShortLabel="@string/shortcut.trip_logs.short_label"
+        android:shortcutLongLabel="@string/shortcut.trip_logs.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.aa"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="trip_logs" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="trip_upload"
+        android:enabled="true"
+        android:icon="@drawable/ic_action_execute"
+        android:shortcutShortLabel="@string/shortcut.trip_upload.short_label"
+        android:shortcutLongLabel="@string/shortcut.trip_upload.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.aa"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="trip_upload" />
+        </intent>
+    </shortcut>
+
+</shortcuts>

--- a/app/src/giuliaPerformanceMonitor/res/xml/shortcuts.xml
+++ b/app/src/giuliaPerformanceMonitor/res/xml/shortcuts.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut
+        android:shortcutId="graph"
+        android:enabled="true"
+        android:icon="@drawable/ic_graph"
+        android:shortcutShortLabel="@string/shortcut.graph.short_label"
+        android:shortcutLongLabel="@string/shortcut.graph.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.performance_monitor"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="graph" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="gauge"
+        android:enabled="true"
+        android:icon="@drawable/ic_gauge"
+        android:shortcutShortLabel="@string/shortcut.gauge.short_label"
+        android:shortcutLongLabel="@string/shortcut.gauge.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.performance_monitor"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="gauge" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="trip_logs"
+        android:enabled="true"
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutShortLabel="@string/shortcut.trip_logs.short_label"
+        android:shortcutLongLabel="@string/shortcut.trip_logs.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.performance_monitor"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="trip_logs" />
+        </intent>
+    </shortcut>
+
+    <shortcut
+        android:shortcutId="trip_upload"
+        android:enabled="true"
+        android:icon="@drawable/ic_action_execute"
+        android:shortcutShortLabel="@string/shortcut.trip_upload.short_label"
+        android:shortcutLongLabel="@string/shortcut.trip_upload.long_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="org.obd.graphs.my.giulia.performance_monitor"
+            android:targetClass="org.obd.graphs.activity.MainActivity">
+            <extra
+                android:name="org.obd.graphs.EXTRA_NAVIGATE_TO"
+                android:value="trip_upload" />
+        </intent>
+    </shortcut>
+
+</shortcuts>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,6 +116,7 @@
         <activity
             android:name="org.obd.graphs.activity.MainActivity"
             android:configChanges="orientation|screenSize"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.App.Starting"
             android:exported="true">
 
@@ -125,6 +126,7 @@
                 <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
             </intent-filter>
             <meta-data android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" android:resource="@xml/usb_device_filter" />
+            <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
 
         </activity>
     </application>

--- a/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
+++ b/app/src/main/java/org/obd/graphs/activity/MainActivity.kt
@@ -53,6 +53,7 @@ import org.obd.graphs.bl.trip.tripManager
 import org.obd.graphs.integrations.gcp.gdrive.TripLogDriveManager
 import org.obd.graphs.language.LanguageManager
 import org.obd.graphs.preferences.setPreferencesContext
+import org.obd.graphs.preferences.trips.TripLogListDialogFragment
 import org.obd.graphs.profile.profile
 import org.obd.graphs.sendBroadcastEvent
 import org.obd.graphs.setActivityContext
@@ -84,6 +85,7 @@ class MainActivity :
     val drawerLayout: DrawerLayout by lazy { findViewById(R.id.drawer_layout) }
 
     private var isAppReady = false
+    private var pendingNavigateTo: String? = null
 
     internal var activityBroadcastReceiver =
         object : BroadcastReceiver() {
@@ -111,6 +113,8 @@ class MainActivity :
         super.onCreate(savedInstanceState)
 
         splashScreen.setKeepOnScreenCondition { !isAppReady }
+
+        pendingNavigateTo = intent?.getStringExtra(EXTRA_NAVIGATE_TO)
 
         runWizardFlow()
 
@@ -182,6 +186,12 @@ class MainActivity :
         }
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        pendingNavigateTo = intent.getStringExtra(EXTRA_NAVIGATE_TO)
+    }
+
     override fun onResume() {
         super.onResume()
         screen.setupWindowManager(this)
@@ -191,6 +201,20 @@ class MainActivity :
         val storedLanguage = LanguageManager.getStoredLanguage(this)
         if (storedLanguage.isNotEmpty() && resources.configuration.locales[0].language != storedLanguage) {
             recreate()
+        }
+
+        pendingNavigateTo?.let {
+            pendingNavigateTo = null
+            handleShortcutNavigation(it)
+        }
+    }
+
+    private fun handleShortcutNavigation(target: String) {
+        when (target) {
+            "graph" -> navigateToScreen(R.id.nav_graph)
+            "gauge" -> navigateToScreen(R.id.nav_gauge)
+            "trip_logs" -> TripLogListDialogFragment().show(supportFragmentManager, null)
+            "trip_upload" -> TripLogListDialogFragment(enableDeleteButtons = false).show(supportFragmentManager, null)
         }
     }
 
@@ -362,5 +386,9 @@ class MainActivity :
                 it.visibility = View.GONE
             }
         }
+    }
+
+    companion object {
+        const val EXTRA_NAVIGATE_TO = "org.obd.graphs.EXTRA_NAVIGATE_TO"
     }
 }

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2,6 +2,15 @@
     <string name="nav_open">Otwórz</string>
     <string name="nav_close">Zamknij</string>
     <string name="app_name">My Giulia</string>
+
+    <string name="shortcut.graph.short_label">Wykres</string>
+    <string name="shortcut.graph.long_label">Otwórz Wykres</string>
+    <string name="shortcut.gauge.short_label">Zegary</string>
+    <string name="shortcut.gauge.long_label">Otwórz Zegary</string>
+    <string name="shortcut.trip_logs.short_label">Trasy</string>
+    <string name="shortcut.trip_logs.long_label">Zobacz trasy</string>
+    <string name="shortcut.trip_upload.short_label">Prześlij trasy</string>
+    <string name="shortcut.trip_upload.long_label">Prześlij trasy do chmury</string>
     <string name="pref.about_title">O aplikacji</string>
 
     <string name="pref.performance.screen_label_y_padding"><b><i>Gauge</i></b> górny margines etykiety</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,15 @@
     <string name="nav_open">Open</string>
     <string name="nav_close">Close</string>
 
+    <string name="shortcut.graph.short_label">Graph</string>
+    <string name="shortcut.graph.long_label">Open Graph</string>
+    <string name="shortcut.gauge.short_label">Gauges</string>
+    <string name="shortcut.gauge.long_label">Open Gauges</string>
+    <string name="shortcut.trip_logs.short_label">Trip Logs</string>
+    <string name="shortcut.trip_logs.long_label">View Trip Logs</string>
+    <string name="shortcut.trip_upload.short_label">Upload Trips</string>
+    <string name="shortcut.trip_upload.long_label">Upload Trips to Cloud</string>
+
     <string name="pref.performance.screen_label_y_padding"><b><i>Gauge</i></b> label top offset</string>
     <string name="pref.performance.screen_top_margin">Top margin</string>
 


### PR DESCRIPTION
Long-press on the launcher icon now exposes shortcuts into Graph, Gauges, Trip Logs, and an upload-focused trip list, routed through MainActivity via a new EXTRA_NAVIGATE_TO intent extra (onNewIntent + singleTop launch mode) reusing the existing navigateToScreen() helper.

Per-flavor shortcuts.xml (giulia/giuliaAA/giuliaPerformanceMonitor) each hardcode their own applicationId as targetPackage, matching how official examples declare static shortcuts - avoids relying on resource-reference resolution for that attribute, which the shortcut-parsing framework's support for is not well documented.