### PR TITLE
feat(trips): move trip details from Graph screen to an expandable tri…

### DIFF
--- a/app/src/main/java/org/obd/graphs/preferences/trips/TripLogListDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/trips/TripLogListDialogFragment.kt
@@ -32,7 +32,9 @@ import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.obd.graphs.R
 import org.obd.graphs.SCREEN_LOCK_PROGRESS_EVENT
 import org.obd.graphs.SCREEN_UNLOCK_PROGRESS_EVENT
@@ -114,7 +116,7 @@ class TripLogListDialogFragment(
                 context,
                 tripManager.findAllTripsBy().map { TripLogDetails(source = it) }.toMutableList(),
                 enableDeleteButtons
-            )
+            ) { details -> loadTripSummary(details) }
 
         val recyclerView: RecyclerView = root.findViewById(R.id.recycler_view)
         recyclerView.layoutManager = GridLayoutManager(context, 1)
@@ -197,5 +199,12 @@ class TripLogListDialogFragment(
             uploadToCloud.visibility = View.GONE
         }
         return root
+    }
+
+    private fun loadTripSummary(details: TripLogDetails) {
+        lifecycleScope.launch {
+            val summary = withContext(Dispatchers.IO) { tripManager.readTripSummary(details.source.fileName) }
+            adapter.setTripSummary(details.source.fileName, summary)
+        }
     }
 }

--- a/app/src/main/java/org/obd/graphs/preferences/trips/TripViewAdapter.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/trips/TripViewAdapter.kt
@@ -39,6 +39,7 @@ import org.obd.graphs.bl.trip.SensorData
 import org.obd.graphs.bl.trip.tripManager
 import org.obd.graphs.format
 import org.obd.graphs.profile.profile
+import org.obd.graphs.ui.common.COLOR_PHILIPPINE_GREEN
 import org.obd.graphs.ui.common.Colors
 import org.obd.graphs.ui.common.setText
 import java.text.SimpleDateFormat
@@ -183,7 +184,7 @@ class TripViewAdapter internal constructor(
             val pid = pidRegistry.findBy(sensorData.id)
             val row = mInflater.inflate(R.layout.item_metric, container, false)
 
-            row.findViewById<TextView>(R.id.metric_name).setText(pid.description, Color.WHITE, Typeface.NORMAL, 1.0f)
+            row.findViewById<TextView>(R.id.metric_name).setText(pid.description, COLOR_PHILIPPINE_GREEN, Typeface.NORMAL, 1.0f)
             row.findViewById<TextView>(R.id.metric_min_value).setText(sensorData.min.format(pid), Color.GRAY, Typeface.NORMAL, 1.0f)
             row.findViewById<TextView>(R.id.metric_max_value).setText(sensorData.max.format(pid), Color.GRAY, Typeface.NORMAL, 1.0f)
             row.findViewById<TextView>(R.id.metric_avg_value).setText(sensorData.mean.format(pid), Color.GRAY, Typeface.NORMAL, 1.0f)

--- a/app/src/main/java/org/obd/graphs/preferences/trips/TripViewAdapter.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/trips/TripViewAdapter.kt
@@ -34,7 +34,10 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.graphics.toColorInt
 import androidx.recyclerview.widget.RecyclerView
 import org.obd.graphs.R
+import org.obd.graphs.bl.datalogger.DataLoggerRepository
+import org.obd.graphs.bl.trip.SensorData
 import org.obd.graphs.bl.trip.tripManager
+import org.obd.graphs.format
 import org.obd.graphs.profile.profile
 import org.obd.graphs.ui.common.Colors
 import org.obd.graphs.ui.common.setText
@@ -47,11 +50,29 @@ private const val LOGGER_KEY = "TripsViewAdapter"
 class TripViewAdapter internal constructor(
     context: Context?,
     var data: MutableCollection<TripLogDetails>,
-    private val showDeleteButton: Boolean = true
+    private val showDeleteButton: Boolean = true,
+    private val onDetailsRequested: (TripLogDetails) -> Unit = {}
 ) : RecyclerView.Adapter<TripViewAdapter.ViewHolder>() {
     private val mInflater: LayoutInflater = LayoutInflater.from(context)
     private val dateFormat: SimpleDateFormat =
         SimpleDateFormat("yyyy.MM.dd HH:mm:ss", Locale.getDefault())
+
+    // Only one row expanded at a time, mirroring DiagnosticTroubleCodeViewAdapter's pattern.
+    private var expandedPosition = RecyclerView.NO_POSITION
+
+    // Keyed by trip file name rather than position, so a cached summary survives list reordering.
+    private val summaryCache = mutableMapOf<String, Map<Long, SensorData>>()
+
+    fun setTripSummary(
+        fileName: String,
+        summary: Map<Long, SensorData>
+    ) {
+        summaryCache[fileName] = summary
+        val position = data.indexOfFirst { it.source.fileName == fileName }
+        if (position != -1) {
+            notifyItemChanged(position)
+        }
+    }
 
     private val profileColors =
         mutableMapOf<String, Int>().apply {
@@ -125,6 +146,50 @@ class TripViewAdapter internal constructor(
 
                 it.setText(text, Color.GRAY, Typeface.BOLD, 0.9f)
             }
+
+            val isExpanded = position == expandedPosition
+            holder.expandedContainer.visibility = if (isExpanded) View.VISIBLE else View.GONE
+
+            if (isExpanded) {
+                val summary = summaryCache[source.fileName]
+                if (summary == null) {
+                    holder.expandedContainer.removeAllViews()
+                    onDetailsRequested(this)
+                } else {
+                    bindSummary(holder.expandedContainer, summary)
+                }
+            }
+
+            holder.itemView.setOnClickListener {
+                val previousExpandedPosition = expandedPosition
+                expandedPosition = if (isExpanded) RecyclerView.NO_POSITION else position
+
+                notifyItemChanged(previousExpandedPosition)
+                notifyItemChanged(expandedPosition)
+            }
+        }
+    }
+
+    // Inflates one item_metric.xml row per PID directly into the expanded container - a nested
+    // RecyclerView isn't worth it here since only one trip row is ever expanded at a time.
+    private fun bindSummary(
+        container: LinearLayout,
+        summary: Map<Long, SensorData>
+    ) {
+        container.removeAllViews()
+        val pidRegistry = DataLoggerRepository.getPidDefinitionRegistry()
+
+        summary.values.forEach { sensorData ->
+            val pid = pidRegistry.findBy(sensorData.id)
+            val row = mInflater.inflate(R.layout.item_metric, container, false)
+
+            row.findViewById<TextView>(R.id.metric_name).setText(pid.description, Color.WHITE, Typeface.NORMAL, 1.0f)
+            row.findViewById<TextView>(R.id.metric_min_value).setText(sensorData.min.format(pid), Color.GRAY, Typeface.NORMAL, 1.0f)
+            row.findViewById<TextView>(R.id.metric_max_value).setText(sensorData.max.format(pid), Color.GRAY, Typeface.NORMAL, 1.0f)
+            row.findViewById<TextView>(R.id.metric_avg_value).setText(sensorData.mean.format(pid), Color.GRAY, Typeface.NORMAL, 1.0f)
+            row.findViewById<TextView>(R.id.metric_value).visibility = View.GONE
+
+            container.addView(row)
         }
     }
 
@@ -137,6 +202,7 @@ class TripViewAdapter internal constructor(
         val vehicleProfile: TextView = binding.findViewById(R.id.vehicle_profile)
         val tripStartDate: TextView = binding.findViewById(R.id.trip_start_date)
         val tripTime: TextView = binding.findViewById(R.id.trip_length)
+        val expandedContainer: LinearLayout = binding.findViewById(R.id.trip_expanded_details_container)
         private val loadTrip: Button = binding.findViewById(R.id.trip_load)
         private val deleteTrip: Button = binding.findViewById(R.id.trip_delete)
         private val actionsContainer: LinearLayout = binding.findViewById(R.id.actions_container)

--- a/app/src/main/java/org/obd/graphs/ui/graph/GraphFragment.kt
+++ b/app/src/main/java/org/obd/graphs/ui/graph/GraphFragment.kt
@@ -31,8 +31,6 @@ import android.widget.Button
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.GridLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.github.mikephil.charting.charts.LineChart
 import com.github.mikephil.charting.components.Legend
 import com.github.mikephil.charting.components.XAxis
@@ -59,7 +57,6 @@ import org.obd.graphs.bl.query.QueryStrategyType
 import org.obd.graphs.bl.trip.SensorData
 import org.obd.graphs.bl.trip.tripManager
 import org.obd.graphs.bl.trip.tripVirtualScreenManager
-import org.obd.graphs.preferences.Prefs
 import org.obd.graphs.registerReceiver
 import org.obd.graphs.ui.common.COLOR_PHILIPPINE_GREEN
 import org.obd.graphs.ui.common.COLOR_TRANSPARENT
@@ -209,69 +206,18 @@ class GraphFragment : Fragment() {
 
         initializeChart(root)
         registerMetricsObserver()
-        initializeTripDetails()
         loadCurrentTrip()
         registerReceivers()
-        configureRecyclerView()
         setupVirtualViewPanel()
         configureActionButton(query())
         configureActionButton(query())
         return root
     }
 
-    private fun configureRecyclerView() {
-        val displayInfoPanel = Prefs.getBoolean("pref.trips.recordings.display_info", true)
-        configureRecyclerView(R.id.graph_view_chart, true, 5f)
-        configureRecyclerView(R.id.graph_view_table_layout, displayInfoPanel, 0.2f)
-        configureRecyclerView(R.id.recycler_view, displayInfoPanel, 1.3f)
-    }
-
-    private fun configureRecyclerView(
-        id: Int,
-        visible: Boolean,
-        weight: Float
-    ) {
-        val view: View = root.findViewById(id)
-        view.visibility = if (visible) View.VISIBLE else View.GONE
-        (view.layoutParams as LinearLayout.LayoutParams).run {
-            this.weight = weight
-            this.width = LinearLayout.LayoutParams.MATCH_PARENT
-        }
-    }
-
     private fun registerMetricsObserver() {
         DataLoggerRepository.observe(viewLifecycleOwner) {
             if (preferences.metrics.contains(it.command.pid.id)) {
                 addEntry(it)
-            }
-        }
-    }
-
-    private fun initializeTripDetails() {
-        val data: MutableList<SensorData> = arrayListOf()
-        val adapter = TripDetailsViewAdapter(root.context, data)
-        val recyclerView: RecyclerView = root.findViewById(R.id.recycler_view)
-
-        recyclerView.layoutManager = GridLayoutManager(root.context, 1)
-        recyclerView.adapter = adapter
-
-        DataLoggerRepository.observe(viewLifecycleOwner) {
-            DataLoggerRepository.findHistogramFor(it).let { hist ->
-                val sensorData =
-                    SensorData(
-                        id = it.command.pid.id,
-                        min = hist.min,
-                        max = hist.max,
-                        mean = hist.mean
-                    )
-                val indexOf = data.indexOf(sensorData)
-                if (indexOf == -1) {
-                    data.add(sensorData)
-                    adapter.notifyItemInserted(data.indexOf(sensorData))
-                } else {
-                    data[indexOf] = sensorData
-                    adapter.notifyItemChanged(indexOf, sensorData)
-                }
             }
         }
     }
@@ -323,11 +269,6 @@ class GraphFragment : Fragment() {
             val trip = tripManager.getCurrentTrip()
             val registry = DataLoggerRepository.getPidDefinitionRegistry()
             tripStartTs = trip.startTs
-
-            val recyclerView: RecyclerView = root.findViewById(R.id.recycler_view)
-            val adapter = recyclerView.adapter as TripDetailsViewAdapter
-            adapter.mData.addAll(trip.entries.values)
-            adapter.notifyDataSetChanged()
 
             trip.entries.let { cache ->
                 chart.run {
@@ -506,7 +447,6 @@ class GraphFragment : Fragment() {
                 preferences = graphPreferencesReader.read()
 
                 initializeChart(root)
-                initializeTripDetails()
                 loadCurrentTrip()
             }
         }

--- a/app/src/main/java/org/obd/graphs/ui/graph/MarkerWindow.kt
+++ b/app/src/main/java/org/obd/graphs/ui/graph/MarkerWindow.kt
@@ -18,12 +18,14 @@ package org.obd.graphs.ui.graph
 
 import android.content.Context
 import android.util.Log
+import android.widget.TextView
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.github.mikephil.charting.charts.LineChart
 import com.github.mikephil.charting.components.MarkerView
 import com.github.mikephil.charting.data.Entry
 import com.github.mikephil.charting.highlight.Highlight
+import com.github.mikephil.charting.interfaces.datasets.ILineDataSet
 import com.github.mikephil.charting.utils.MPPointF
 import org.obd.graphs.R
 import org.obd.graphs.bl.datalogger.DataLoggerRepository
@@ -31,9 +33,17 @@ import org.obd.graphs.bl.datalogger.scaleToRange
 import org.obd.metrics.api.model.ObdMetric
 import org.obd.metrics.command.obd.ObdCommand
 import org.obd.metrics.pid.PidDefinitionRegistry
+import java.util.Locale
 
 private const val SEARCH_SCOPE = 300
 private const val LOG_KEY = "MarkerWindow"
+
+data class MarkerMetric(
+    val obdMetric: ObdMetric,
+    val min: Double,
+    val max: Double,
+    val mean: Double
+)
 
 class MarkerWindow(
     context: Context?,
@@ -45,6 +55,8 @@ class MarkerWindow(
         e: Entry,
         highlight: Highlight?
     ) {
+        findViewById<TextView>(R.id.marker_timestamp)?.text = formatElapsedTime(e.x)
+
         val metrics = findClosestMetrics(e)
         val adapter = MarkerWindowViewAdapter(context, metrics)
         val recyclerView: RecyclerView = findViewById(R.id.recycler_view)
@@ -55,30 +67,35 @@ class MarkerWindow(
 
     override fun getOffset(): MPPointF = MPPointF.getInstance(-(width / 2).toFloat(), -height.toFloat())
 
-    private fun findClosestMetrics(e: Entry): MutableCollection<ObdMetric> {
-        val metricsMap = mutableMapOf<Long, ObdMetric>()
+    private fun formatElapsedTime(elapsedMs: Float): String {
+        val totalSeconds = (elapsedMs / 1000).toInt()
+        return String.format(Locale.getDefault(), "%02d:%02d", totalSeconds / 60, totalSeconds % 60)
+    }
+
+    private fun findClosestMetrics(e: Entry): MutableCollection<MarkerMetric> {
+        val metricsMap = mutableMapOf<Long, MarkerMetric>()
         e.data?.let {
             metricsMap[(e.data.toString().toLong())] =
-                buildMetrics((e.data.toString().toLong()), e.y)
+                buildMetrics((e.data.toString().toLong()), e.y, listOf(e.y))
         }
 
         var time = System.currentTimeMillis()
-        chart.data.dataSets.forEach {
+        chart.data.dataSets.forEach { dataSet ->
             var x = 0
 
             do {
-                val entriesForXValue = it.getEntriesForXValue(e.x + x)
+                val entriesForXValue = dataSet.getEntriesForXValue(e.x + x)
                 if (entriesForXValue.isNotEmpty()) {
                     entriesForXValue.forEach { entry ->
                         e.data?.let {
                             val id = entry.data.toString().toLong()
                             metricsMap[id] =
-                                buildMetrics(id, entry.y)
+                                buildMetrics(id, entry.y, valuesUpTo(dataSet, entry.x))
                         }
                     }
                 } else {
                     if (x > SEARCH_SCOPE) {
-                        Log.d(LOG_KEY, "Did not find entry for=${it.label}.")
+                        Log.d(LOG_KEY, "Did not find entry for=${dataSet.label}.")
                         break
                     }
                     x = updateXValue(x)
@@ -87,8 +104,19 @@ class MarkerWindow(
         }
         time = System.currentTimeMillis() - time
         Log.d(LOG_KEY, "Build map, time: ${time}ms , values: ${metricsMap.values}.")
-        return metricsMap.values.sortedBy { i -> i.command.pid.description }.toMutableList()
+        return metricsMap.values.sortedBy { i -> i.obdMetric.command.pid.description }.toMutableList()
     }
+
+    // The trip's running min/max/mean up to this point in time - not the trip-wide stats
+    // already shown in the side panel, which is why this is computed per-tap rather than reused.
+    private fun valuesUpTo(
+        dataSet: ILineDataSet,
+        x: Float
+    ): List<Float> =
+        (0 until dataSet.entryCount)
+            .map { dataSet.getEntryForIndex(it) }
+            .filter { it.x <= x }
+            .map { it.y }
 
     private fun updateXValue(x: Int): Int {
         var x1 = x
@@ -109,15 +137,25 @@ class MarkerWindow(
 
     private fun buildMetrics(
         id: Long,
-        v: Float
-    ): ObdMetric {
+        v: Float,
+        rawValuesUpToNow: List<Float>
+    ): MarkerMetric {
         val pidRegistry: PidDefinitionRegistry = DataLoggerRepository.getPidDefinitionRegistry()
         val pid = pidRegistry.findBy(id)
         val value = pid.scaleToRange(v)
-        return ObdMetric
-            .builder()
-            .command(ObdCommand(pid))
-            .value(value)
-            .build()
+        val obdMetric =
+            ObdMetric
+                .builder()
+                .command(ObdCommand(pid))
+                .value(value)
+                .build()
+
+        val values = rawValuesUpToNow.ifEmpty { listOf(v) }
+        return MarkerMetric(
+            obdMetric = obdMetric,
+            min = pid.scaleToRange(values.min()).toDouble(),
+            max = pid.scaleToRange(values.max()).toDouble(),
+            mean = pid.scaleToRange(values.average().toFloat()).toDouble()
+        )
     }
 }

--- a/app/src/main/java/org/obd/graphs/ui/graph/MarkerWindowViewAdapter.kt
+++ b/app/src/main/java/org/obd/graphs/ui/graph/MarkerWindowViewAdapter.kt
@@ -17,20 +17,21 @@
 package org.obd.graphs.ui.graph
 
 import android.content.Context
+import android.graphics.Color
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import org.obd.graphs.R
+import org.obd.graphs.format
 import org.obd.graphs.ui.common.COLOR_LIGHT_SHADE_GRAY
 import org.obd.graphs.ui.common.COLOR_PHILIPPINE_GREEN
 import org.obd.graphs.ui.common.setText
-import org.obd.metrics.api.model.ObdMetric
 
 class MarkerWindowViewAdapter internal constructor(
     context: Context?,
-    private var data: MutableCollection<ObdMetric>
+    private var data: MutableCollection<MarkerMetric>
 ) : RecyclerView.Adapter<MarkerWindowViewAdapter.ViewHolder>() {
     private val mInflater: LayoutInflater = LayoutInflater.from(context)
 
@@ -47,8 +48,14 @@ class MarkerWindowViewAdapter internal constructor(
         position: Int
     ) {
         data.elementAt(position).run {
-            holder.metricName.setText(command.label, COLOR_PHILIPPINE_GREEN, 1.0f)
-            holder.metricValue.setText(valueToString(), COLOR_LIGHT_SHADE_GRAY, 1.0f)
+            val pid = obdMetric.command.pid
+            val units = pid.units ?: ""
+
+            holder.metricName.setText(obdMetric.command.label, COLOR_PHILIPPINE_GREEN, 1.0f)
+            holder.metricValue.setText("${obdMetric.valueToString()} $units".trim(), COLOR_LIGHT_SHADE_GRAY, 1.0f)
+            holder.metricMinValue.setText("${min.format(pid)} $units".trim(), Color.GRAY, 1.0f)
+            holder.metricMaxValue.setText("${max.format(pid)} $units".trim(), Color.GRAY, 1.0f)
+            holder.metricMeanValue.setText("${mean.format(pid)} $units".trim(), Color.GRAY, 1.0f)
         }
     }
 
@@ -60,23 +67,15 @@ class MarkerWindowViewAdapter internal constructor(
         View.OnClickListener {
         val metricName: TextView = itemView.findViewById(R.id.metric_name)
         val metricValue: TextView = itemView.findViewById(R.id.metric_value)
+        val metricMinValue: TextView = itemView.findViewById(R.id.metric_min_value)
+        val metricMaxValue: TextView = itemView.findViewById(R.id.metric_max_value)
+        val metricMeanValue: TextView = itemView.findViewById(R.id.metric_avg_value)
 
         override fun onClick(view: View?) {
         }
 
         init {
             itemView.setOnClickListener(this)
-            itemView.findViewById<TextView>(R.id.metric_max_value).apply {
-                visibility = View.GONE
-            }
-
-            itemView.findViewById<TextView>(R.id.metric_min_value).apply {
-                visibility = View.GONE
-            }
-
-            itemView.findViewById<TextView>(R.id.metric_avg_value).apply {
-                visibility = View.GONE
-            }
         }
     }
 }

--- a/app/src/main/res/layout/fragment_graph.xml
+++ b/app/src/main/res/layout/fragment_graph.xml
@@ -80,87 +80,8 @@
             android:id="@+id/graph_view_chart"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="5"
+            android:layout_weight="1"
             android:background="@color/black" />
-
-        <TableLayout
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_weight="0.2"
-            android:paddingStart="0dp"
-            android:paddingEnd="2dip">
-
-            <TableRow
-                android:id="@+id/graph_view_table_layout"
-                android:layout_width="fill_parent"
-                android:layout_height="0dp"
-
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_weight="1.5"
-                    android:gravity="start"
-                    android:paddingStart="4dp"
-                    android:paddingEnd="0dp"
-                    android:text="@string/pid.metric_name"
-                    android:textAllCaps="false"
-                    android:textColor="@color/cardinal"
-                    android:textSize="16sp"
-                    android:textStyle="normal" />
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:text="@string/pid.value_min"
-                    android:textColor="@color/cardinal"
-                    android:textSize="16sp"
-                    android:textStyle="normal" />
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:text="@string/pid.value_max"
-                    android:textColor="@color/cardinal"
-                    android:textSize="16sp"
-                    android:textStyle="normal" />
-
-                <TextView
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:gravity="end"
-                    android:paddingStart="0dp"
-                    android:paddingEnd="6dp"
-                    android:text="@string/pid.value_avg"
-                    android:textColor="@color/cardinal"
-                    android:textSize="16sp"
-                    android:textStyle="normal" />
-            </TableRow>
-
-            <TableRow
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="2dip"
-                    android:layout_weight="2"
-                    android:background="#FF909090"
-                    android:padding="2dip" />
-            </TableRow>
-        </TableLayout>
-
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1.5" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/graph_marker_view.xml
+++ b/app/src/main/res/layout/graph_marker_view.xml
@@ -5,9 +5,20 @@
     android:layout_height="wrap_content"
     android:background="@drawable/transparent_window_background">
 
+    <TextView
+        android:id="@+id/marker_timestamp"
+        android:layout_width="340dp"
+        android:layout_height="wrap_content"
+        android:gravity="start"
+        android:paddingStart="4dp"
+        android:paddingTop="2dp"
+        android:textColor="@color/white"
+        android:textSize="12sp" />
+
     <TableRow
-        android:layout_width="260dp"
+        android:layout_width="340dp"
         android:layout_height="fill_parent"
+        android:layout_marginTop="20dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -39,5 +50,5 @@
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="26dp" />
+        android:layout_marginTop="46dp" />
 </RelativeLayout>

--- a/app/src/main/res/layout/item_trip.xml
+++ b/app/src/main/res/layout/item_trip.xml
@@ -115,7 +115,7 @@
         android:id="@+id/trip_expanded_details_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:background="@color/dialog_card_background"
+        android:background="@color/surface_variant"
         android:orientation="vertical"
         android:paddingStart="4dp"
         android:paddingEnd="4dp"

--- a/app/src/main/res/layout/item_trip.xml
+++ b/app/src/main/res/layout/item_trip.xml
@@ -12,7 +12,6 @@
         android:background="@color/dialog_card_background"
         android:paddingStart="0dp"
         android:paddingEnd="2dip"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -111,4 +110,19 @@
                 android:padding="2dip" />
         </TableRow>
     </TableLayout>
+
+    <LinearLayout
+        android:id="@+id/trip_expanded_details_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/dialog_card_background"
+        android:orientation="vertical"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp"
+        android:paddingBottom="4dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tablelayout" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -467,7 +467,6 @@
     <string name="pref.view.navigation.navigate_to_last_visited_view">Przejdź do ostatnio odwiedzonego widoku</string>
     <string name="pref.view.navigation.navigate_to_last_visited_view_summary">Po włączeniu aplikacja podczas uruchamiania otwiera ostatnio odwiedzony widok</string>
 
-    <string name="pref.graph.trips_recordings_display_info">Wyświetl informacje o trasie</string>
     <string name="pref.graph.trips_recordings_save_short_trip">Rejestruj trasy krótsze niż 5s (start silnika)</string>
     <string name="pref.graph.x_axis_start_moving_after_time">Oś X zaczyna się przesuwać po</string>
     <string name="pref.graph.x_axis_minimum_shift_time">Czas przesuwania osi X</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -467,7 +467,6 @@
     <string name="pref.view.navigation.navigate_to_last_visited_view">Navigate to last visited view</string>
     <string name="pref.view.navigation.navigate_to_last_visited_view_summary">When enabled, app during startup opens last visited view</string>
 
-    <string name="pref.graph.trips_recordings_display_info">Display trip info</string>
     <string name="pref.graph.trips_recordings_save_short_trip">Record trips shorten than 5s length (engine start)</string>
     <string name="pref.graph.x_axis_start_moving_after_time">X-Axis start moving after</string>
     <string name="pref.graph.x_axis_minimum_shift_time">X-Axis moving time</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2050,11 +2050,6 @@
                 <PreferenceCategory android:title="@string/pref.trips_category">
                     <SwitchPreferenceCompat
                         android:defaultValue="false"
-                        android:key="pref.trips.recordings.display_info"
-                        android:title="@string/pref.graph.trips_recordings_display_info" />
-
-                    <SwitchPreferenceCompat
-                        android:defaultValue="false"
                         android:key="pref.trips.recordings.save.short.trip"
                         android:title="@string/pref.graph.trips_recordings_save_short_trip"
                         app:singleLineTitle="false" />

--- a/datalogger/src/main/java/org/obd/graphs/bl/trip/DefaultTripManager.kt
+++ b/datalogger/src/main/java/org/obd/graphs/bl/trip/DefaultTripManager.kt
@@ -162,6 +162,31 @@ internal class DefaultTripManager : TripManager {
         }
     }
 
+    override fun readTripSummary(tripName: String): Map<Long, SensorData> {
+        val trip = Trip(startTs = 0)
+
+        return try {
+            repository.loadTrip(tripName) { metric ->
+                val key = metric.entry.data
+                trip.entries.getOrPut(key) { SensorData(id = key) }.metrics.add(metric)
+            }
+
+            trip.entries.values.forEach { sensorData ->
+                val values = sensorData.metrics.mapNotNull { it.entry.y.toString().toFloatOrNull() }
+                if (values.isNotEmpty()) {
+                    sensorData.min = values.minOrNull() ?: 0f
+                    sensorData.max = values.maxOrNull() ?: 0f
+                    sensorData.mean = values.average()
+                }
+            }
+
+            trip.entries
+        } catch (e: Throwable) {
+            Log.e(LOG_TAG, "Failed to read trip summary for '$tripName'.", e)
+            emptyMap()
+        }
+    }
+
     override fun saveCurrentTrip() {
         sendBroadcastEvent(
             SCREEN_LOCK_PROGRESS_EVENT,

--- a/datalogger/src/main/java/org/obd/graphs/bl/trip/TripManager.kt
+++ b/datalogger/src/main/java/org/obd/graphs/bl/trip/TripManager.kt
@@ -29,4 +29,8 @@ interface TripManager : MetricsProcessor {
     fun findAllTripsBy(filter: String = ""): MutableCollection<TripFileDesc>
     fun deleteTrip(trip: TripFileDesc)
     fun loadTrip(tripName: String)
+
+    // Pure read - unlike loadTrip(), does not touch the active trip cache, lock the screen, or
+    // require logging to be stopped. Safe to call for any trip just to inspect its stats.
+    fun readTripSummary(tripName: String): Map<Long, SensorData>
 }


### PR DESCRIPTION
…p list row

Removes the Graph screen's side panel (only ever showed live data, blank when reviewing a past trip) along with its Settings toggle, and adds TripManager.readTripSummary() - a pure, side-effect-free read (unlike loadTrip(), no screen lock or active-trip mutation) used to show a given trip's per-PID min/max/mean by tapping its row in the trip list, expanding in place exactly like the DTC list's row pattern rather than a popup.

Also improves the Graph chart's tap-on-point marker popup: adds units, the tapped point's elapsed time, and running min/max/mean up to that point (previously hidden despite the layout supporting it).