### PR TITLE
chore: target Android 16 (API level 36)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 project.ext {
-    compileSdkVersion = 35
+    compileSdkVersion = 36
     minSdkVersion = 26
 }
 


### PR DESCRIPTION
Google Play now requires new app updates to target API level 36 (Android 16). Bumped compileSdkVersion/targetSdkVersion from 35 to 36 in the shared project.ext block, which every module inherits. Verified against AGP 8.8.0 / Gradle 8.10.2 - no toolchain bump needed. All three flavors (giulia, giuliaAA, giuliaPerformanceMonitor) assemble cleanly.

Reviewed for Android 16 behavior changes that could affect this app:
- Large-screen adaptivity (orientation locking ignored by default for API 36+): no android:screenOrientation or setRequestedOrientation usage anywhere in the codebase, so nothing to adjust.
- Predictive back: MainActivity already uses OnBackPressedCallback: the manifest doesn't set android:enableOnBackInvokedCallback, so the system's predictive-back cross-activity animation stays off - in-app back handling is unaffected either way. Worth a follow-up if the animation is desired.
- Edge-to-edge enforcement (started at API 35, unchanged by this bump): only SetupWizardActivity currently handles insets via WindowCompat/ViewCompat; MainActivity has no inset handling, but that's pre-existing since the app already targeted 35.
- No native libraries (.so) built into the app, so the 16KB page size requirement isn't a concern here.