### PR TITLE
feat(pid,dri): add risky-mode save guardrail and ECU module auto-disc…

### DIFF
--- a/app/src/main/java/org/obd/graphs/preferences/dri/DiagnosticRequestIdFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/dri/DiagnosticRequestIdFragment.kt
@@ -45,6 +45,7 @@ class DiagnosticRequestIdFragment : Fragment() {
 
         val recyclerView = view.findViewById<RecyclerView>(R.id.recyclerView)
         val fabAdd = view.findViewById<FloatingActionButton>(R.id.fabAdd)
+        val fabDiscover = view.findViewById<FloatingActionButton>(R.id.fabDiscover)
 
         adapter = DiagnosticRequestIdAdapter(
             items = DiagnosticRequestIDManager.getMappings().toMutableList(),
@@ -57,6 +58,11 @@ class DiagnosticRequestIdFragment : Fragment() {
 
         fabAdd.setOnClickListener {
             showEditDialog(null)
+        }
+
+        fabDiscover.setOnClickListener {
+            EcuDiscoveryDialogFragment(onModulesAdded = { refreshList() })
+                .show(childFragmentManager, "EcuDiscoveryDialogFragment")
         }
     }
 

--- a/app/src/main/java/org/obd/graphs/preferences/dri/EcuDiscoveryDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/dri/EcuDiscoveryDialogFragment.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.preferences.dri
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputEditText
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import org.obd.graphs.DiagnosticRequestIDManager
+import org.obd.graphs.R
+import org.obd.graphs.bl.datalogger.DataLoggerRepository
+import org.obd.graphs.bl.datalogger.MODULE_DISCOVERY_RESULT_EVENT
+import org.obd.graphs.bl.datalogger.ModuleDiscoveryResult
+import org.obd.graphs.getSerializableCompat
+import org.obd.graphs.registerReceiver
+import org.obd.graphs.ui.common.toast
+import org.obd.graphs.ui.withDataLogger
+
+private const val PROBE_TIMEOUT_MS = 1500L
+
+// Sweeps a range of candidate CAN headers (default DAxxF1, the convention used across every
+// bundled Giorgio-platform profile) with a UDS TesterPresent probe, letting the user add whichever
+// headers answer as new (unnamed) Diagnostic Request ID entries - renamed afterward via the
+// existing DRI edit UI, same as any other entry.
+class EcuDiscoveryDialogFragment(
+    private val onModulesAdded: () -> Unit
+) : BottomSheetDialogFragment() {
+
+    private var sweepJob: Job? = null
+    private val checkboxes = mutableMapOf<String, CheckBox>()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.dialog_ecu_discovery, container, false)
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val etHeaderPrefix = view.findViewById<TextInputEditText>(R.id.etHeaderPrefix)
+        val etHeaderSuffix = view.findViewById<TextInputEditText>(R.id.etHeaderSuffix)
+        val etRangeStart = view.findViewById<TextInputEditText>(R.id.etRangeStart)
+        val etRangeEnd = view.findViewById<TextInputEditText>(R.id.etRangeEnd)
+        val tvStatus = view.findViewById<TextView>(R.id.tvStatus)
+        val progressBar = view.findViewById<ProgressBar>(R.id.progressBar)
+        val btnStart = view.findViewById<MaterialButton>(R.id.btnStart)
+        val btnCancel = view.findViewById<MaterialButton>(R.id.btnCancel)
+        val tvResultsTitle = view.findViewById<TextView>(R.id.tvResultsTitle)
+        val llResults = view.findViewById<android.widget.LinearLayout>(R.id.llResults)
+        val btnAddToDri = view.findViewById<MaterialButton>(R.id.btnAddToDri)
+
+        btnStart.setOnClickListener {
+            if (!DataLoggerRepository.isRunning()) {
+                toast(R.string.pref_dtc_no_connection_established)
+                return@setOnClickListener
+            }
+
+            val prefix = etHeaderPrefix.text.toString().trim().uppercase()
+            val suffix = etHeaderSuffix.text.toString().trim().uppercase()
+            val start = etRangeStart.text.toString().trim().toIntOrNull(16)
+            val end = etRangeEnd.text.toString().trim().toIntOrNull(16)
+
+            if (start == null || end == null || start !in 0..255 || end !in 0..255 || start > end) {
+                toast(R.string.pref_adapter_ecu_discovery_invalid_range)
+                return@setOnClickListener
+            }
+
+            checkboxes.clear()
+            llResults.removeAllViews()
+            tvResultsTitle.visibility = View.GONE
+            btnAddToDri.visibility = View.GONE
+            btnStart.visibility = View.GONE
+            btnCancel.visibility = View.VISIBLE
+            progressBar.visibility = View.VISIBLE
+            progressBar.progress = 0
+            progressBar.max = end - start + 1
+
+            sweepJob = viewLifecycleOwner.lifecycleScope.launch {
+                val total = end - start + 1
+                for (b in start..end) {
+                    val header = "$prefix${"%02X".format(b)}$suffix"
+                    tvStatus.text = getString(
+                        R.string.pref_adapter_ecu_discovery_status_scanning,
+                        header,
+                        b - start + 1,
+                        total
+                    )
+
+                    if (probeHeader(header)) {
+                        addResultRow(llResults, header)
+                        tvResultsTitle.visibility = View.VISIBLE
+                        btnAddToDri.visibility = View.VISIBLE
+                    }
+
+                    progressBar.progress = b - start + 1
+                }
+
+                tvStatus.text = getString(R.string.pref_adapter_ecu_discovery_status_done, checkboxes.size)
+                progressBar.visibility = View.GONE
+                btnCancel.visibility = View.GONE
+                btnStart.visibility = View.VISIBLE
+            }
+        }
+
+        btnCancel.setOnClickListener {
+            sweepJob?.cancel()
+            tvStatus.text = getString(R.string.pref_adapter_ecu_discovery_status_done, checkboxes.size)
+            progressBar.visibility = View.GONE
+            btnCancel.visibility = View.GONE
+            btnStart.visibility = View.VISIBLE
+        }
+
+        btnAddToDri.setOnClickListener {
+            checkboxes.filterValues { it.isChecked }.keys.forEach { header ->
+                DiagnosticRequestIDManager.addMapping(
+                    requestKey = header,
+                    headerValue = header,
+                    description = getString(R.string.pref_adapter_ecu_discovery_discovered_description)
+                )
+            }
+            onModulesAdded()
+            dismiss()
+        }
+    }
+
+    private fun addResultRow(
+        container: android.widget.LinearLayout,
+        header: String
+    ) {
+        val checkBox = CheckBox(requireContext())
+        checkBox.text = header
+        checkBox.isChecked = true
+        container.addView(checkBox)
+        checkboxes[header] = checkBox
+    }
+
+    private suspend fun probeHeader(header: String): Boolean =
+        withTimeoutOrNull(PROBE_TIMEOUT_MS) {
+            suspendCancellableCoroutine { continuation ->
+                val receiver = object : BroadcastReceiver() {
+                    override fun onReceive(context: Context?, intent: Intent?) {
+                        val result = intent?.getSerializableCompat<ModuleDiscoveryResult>() ?: return
+                        if (result.header == header) {
+                            runCatching { requireContext().unregisterReceiver(this) }
+                            if (continuation.isActive) {
+                                continuation.resume(result.found, onCancellation = null)
+                            }
+                        }
+                    }
+                }
+
+                registerReceiver(requireContext(), receiver) { it.addAction(MODULE_DISCOVERY_RESULT_EVENT) }
+                continuation.invokeOnCancellation {
+                    runCatching { requireContext().unregisterReceiver(receiver) }
+                }
+
+                withDataLogger { discoverModule(header) }
+            }
+        } ?: false
+
+    override fun onDestroyView() {
+        sweepJob?.cancel()
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/org/obd/graphs/preferences/pid/EditPidBottomSheet.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/EditPidBottomSheet.kt
@@ -16,6 +16,7 @@
  */
 package org.obd.graphs.preferences.pid
 
+import android.app.AlertDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -38,6 +39,16 @@ import org.obd.metrics.pid.ValueType
 import javax.script.Compilable
 import javax.script.ScriptEngineManager
 import javax.script.SimpleBindings
+
+// Modes that can alter vehicle/ECU state rather than just read data. etMode is a free-text
+// AutoCompleteTextView (like etCanHeader), so this guards manually typed modes too, not just the
+// ones offered in the dropdown.
+private val RISKY_MODES = mapOf(
+    "04" to "Clears stored Diagnostic Trouble Codes on the vehicle.",
+    "08" to "Sends a component/actuator control command directly to the ECU.",
+    "2E" to "Writes data to the ECU (WriteDataByIdentifier) — can permanently alter configuration.",
+    "31" to "Starts an ECU routine (RoutineControl) — may trigger actuator tests or resets."
+)
 
 data class PidFormData(
     val description: String?,
@@ -244,9 +255,33 @@ class EditPidBottomSheet(
                 return@setOnClickListener
             }
 
-            onSave(formData)
-            dismiss()
+            val riskyModeReason = RISKY_MODES[formData.mode]
+            if (riskyModeReason != null) {
+                confirmRiskyModeThenSave(formData.mode!!, riskyModeReason) {
+                    onSave(formData)
+                    dismiss()
+                }
+            } else {
+                onSave(formData)
+                dismiss()
+            }
         }
+    }
+
+    private fun confirmRiskyModeThenSave(
+        mode: String,
+        reason: String,
+        onConfirmed: () -> Unit
+    ) {
+        AlertDialog.Builder(requireContext())
+            .setTitle(getString(R.string.pref_pid_manage_dialog_risky_mode_title))
+            .setMessage(getString(R.string.pref_pid_manage_dialog_risky_mode_message, mode, reason))
+            .setPositiveButton(R.string.pref_pid_manage_dialog_risky_mode_save_anyway) { dialog, _ ->
+                dialog.dismiss()
+                onConfirmed()
+            }
+            .setNegativeButton(R.string.pref_pid_manage_dialog_risky_mode_cancel, null)
+            .show()
     }
 
     private fun extractFormData(

--- a/app/src/main/res/layout/dialog_ecu_discovery.xml
+++ b/app/src/main/res/layout/dialog_ecu_discovery.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tvDialogTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/pref.adapter.ecu_discovery.title"
+            android:textAppearance="?attr/textAppearanceHeadline6" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1"
+                android:hint="@string/pref.adapter.ecu_discovery.prefix_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etHeaderPrefix"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="DA" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/pref.adapter.ecu_discovery.suffix_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etHeaderSuffix"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="F1" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:layout_weight="1"
+                android:hint="@string/pref.adapter.ecu_discovery.range_start_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etRangeStart"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="00" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="@string/pref.adapter.ecu_discovery.range_end_hint">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etRangeEnd"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="FF" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tvStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/pref.adapter.ecu_discovery.status_idle" />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:max="100"
+            android:progress="0"
+            android:visibility="gone" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnStart"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/pref.adapter.ecu_discovery.start_button" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCancel"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/pref.adapter.ecu_discovery.cancel_button"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tvResultsTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/pref.adapter.ecu_discovery.results_title"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:visibility="gone" />
+
+        <LinearLayout
+            android:id="@+id/llResults"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnAddToDri"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/pref.adapter.ecu_discovery.add_to_dri_button"
+            android:visibility="gone" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_dri_manager.xml
+++ b/app/src/main/res/layout/fragment_dri_manager.xml
@@ -28,4 +28,14 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabDiscover"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:contentDescription="@string/pref.adapter.ecu_discovery.fab_content_description"
+        app:srcCompat="@android:drawable/ic_menu_search"
+        app:layout_constraintBottom_toTopOf="@id/fabAdd"
+        app:layout_constraintEnd_toEndOf="@id/fabAdd" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -147,6 +147,22 @@
     <string name="pref.adapter.diagnostic_request_id.key_hint">Klucz żądania (np. 555)</string>
     <string name="pref.adapter.diagnostic_request_id.value_hint">Wartość nagłówka (np. 18DA18F1)</string>
     <string name="pref.adapter.diagnostic_request_id.save_button">Zapisz mapowanie</string>
+
+    <string name="pref.adapter.ecu_discovery.fab_content_description">Wykryj moduły</string>
+    <string name="pref.adapter.ecu_discovery.title">Wykryj moduły ECU</string>
+    <string name="pref.adapter.ecu_discovery.prefix_hint">Prefiks nagłówka</string>
+    <string name="pref.adapter.ecu_discovery.suffix_hint">Sufiks nagłówka</string>
+    <string name="pref.adapter.ecu_discovery.range_start_hint">Początek zakresu (hex)</string>
+    <string name="pref.adapter.ecu_discovery.range_end_hint">Koniec zakresu (hex)</string>
+    <string name="pref.adapter.ecu_discovery.status_idle">Brak połączenia z modułem. Wymaga aktywnego połączenia. Pełny zakres 00-FF może potrwać kilka minut - zawęź zakres lub anuluj w dowolnym momencie.</string>
+    <string name="pref.adapter.ecu_discovery.status_scanning">Skanowanie %1$s (%2$d/%3$d)…</string>
+    <string name="pref.adapter.ecu_discovery.status_done">Skanowanie zakończone. Znaleziono %1$d moduł(ów).</string>
+    <string name="pref.adapter.ecu_discovery.start_button">Rozpocznij skanowanie</string>
+    <string name="pref.adapter.ecu_discovery.cancel_button">Anuluj</string>
+    <string name="pref.adapter.ecu_discovery.results_title">Znalezione moduły</string>
+    <string name="pref.adapter.ecu_discovery.add_to_dri_button">Dodaj zaznaczone do tabeli DRI</string>
+    <string name="pref.adapter.ecu_discovery.invalid_range">Podaj prawidłowy zakres hex od 00 do FF, gdzie początek ≤ koniec.</string>
+    <string name="pref.adapter.ecu_discovery.discovered_description">Wykryty moduł</string>
     <string name="pref.adapter.diagnostic_request_id.edit_mapping_desc">Edytuj mapowanie</string>
     <string name="pref.adapter.diagnostic_request_id.delete_mapping_desc">Usuń mapowanie</string>
     <string name="pref.pid.manage_dialog">Zarządzaj PIDami</string>
@@ -171,6 +187,10 @@
     <string name="pref.pid.manage_dialog.edit_pid_title">Edytuj PID</string>
     <string name="pref.pid.manage_dialog.add_new_pid_title">Dodaj nowy PID</string>
     <string name="pref.pid.manage_dialog.validation_required_fields">Opis, Tryb, Kod PID, Formuła, Min i Max są wymagane!</string>
+    <string name="pref.pid.manage_dialog.risky_mode_title">Potencjalnie niebezpieczny tryb</string>
+    <string name="pref.pid.manage_dialog.risky_mode_message">Tryb %1$s może wpłynąć na pojazd: %2$s\n\nCzy na pewno chcesz zapisać ten PID?</string>
+    <string name="pref.pid.manage_dialog.risky_mode_save_anyway">Zapisz mimo to</string>
+    <string name="pref.pid.manage_dialog.risky_mode_cancel">Anuluj</string>
     <string name="pref.pid.manage_dialog.hint_description">Opis (np. Temp. Oleju)</string>
     <string name="pref.pid.manage_dialog.hint_long_description">Długi opis</string>
     <string name="pref.pid.manage_dialog.hint_mode">Tryb (np. 01)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,10 @@
     <string name="pref.pid.manage_dialog.edit_pid_title">Edit PID</string>
     <string name="pref.pid.manage_dialog.add_new_pid_title">Add New PID</string>
     <string name="pref.pid.manage_dialog.validation_required_fields">Description, Mode, PID Code, Formula, Min, and Max are required!</string>
+    <string name="pref.pid.manage_dialog.risky_mode_title">Potentially unsafe mode</string>
+    <string name="pref.pid.manage_dialog.risky_mode_message">Mode %1$s can affect your vehicle: %2$s\n\nAre you sure you want to save this PID?</string>
+    <string name="pref.pid.manage_dialog.risky_mode_save_anyway">Save anyway</string>
+    <string name="pref.pid.manage_dialog.risky_mode_cancel">Cancel</string>
     <string name="pref.pid.manage_dialog.hint_description">Description (e.g. Oil Temp)</string>
     <string name="pref.pid.manage_dialog.hint_long_description">Long Description</string>
     <string name="pref.pid.manage_dialog.hint_mode">Mode (e.g. 01)</string>
@@ -195,6 +199,22 @@
     <string name="pref.adapter.diagnostic_request_id.key_hint">Request Key (e.g. 555)</string>
     <string name="pref.adapter.diagnostic_request_id.value_hint">Header Value (e.g. 18DA18F1)</string>
     <string name="pref.adapter.diagnostic_request_id.save_button">Save Mapping</string>
+
+    <string name="pref.adapter.ecu_discovery.fab_content_description">Discover Modules</string>
+    <string name="pref.adapter.ecu_discovery.title">Discover ECU Modules</string>
+    <string name="pref.adapter.ecu_discovery.prefix_hint">Header Prefix</string>
+    <string name="pref.adapter.ecu_discovery.suffix_hint">Header Suffix</string>
+    <string name="pref.adapter.ecu_discovery.range_start_hint">Range Start (hex)</string>
+    <string name="pref.adapter.ecu_discovery.range_end_hint">Range End (hex)</string>
+    <string name="pref.adapter.ecu_discovery.status_idle">Not connected to any module. Requires an active connection. A full 00-FF range can take several minutes - narrow the range or cancel anytime.</string>
+    <string name="pref.adapter.ecu_discovery.status_scanning">Scanning %1$s (%2$d/%3$d)…</string>
+    <string name="pref.adapter.ecu_discovery.status_done">Scan finished. Found %1$d module(s).</string>
+    <string name="pref.adapter.ecu_discovery.start_button">Start Scan</string>
+    <string name="pref.adapter.ecu_discovery.cancel_button">Cancel</string>
+    <string name="pref.adapter.ecu_discovery.results_title">Found Modules</string>
+    <string name="pref.adapter.ecu_discovery.add_to_dri_button">Add Selected to DRI Table</string>
+    <string name="pref.adapter.ecu_discovery.invalid_range">Enter a valid hex range between 00 and FF, with start ≤ end.</string>
+    <string name="pref.adapter.ecu_discovery.discovered_description">Discovered module</string>
 
 
     <string name="pref_pid_alert_edit_title">Edit PID Alerting</string>

--- a/datalogger/src/main/java/org/obd/graphs/bl/datalogger/DataLoggerConstants.kt
+++ b/datalogger/src/main/java/org/obd/graphs/bl/datalogger/DataLoggerConstants.kt
@@ -39,4 +39,6 @@ const val ROUTINE_REJECTED_EVENT = "data.logger.routine.rejected"
 const val ROUTINE_WORKFLOW_NOT_RUNNING_EVENT = "data.logger.routine.workflow_not_running"
 const val ROUTINE_UNKNOWN_STATUS_EVENT = "data.logger.routine.unknown_status"
 
+const val MODULE_DISCOVERY_RESULT_EVENT = "data.logger.module_discovery.result"
+
 internal const val LOG_TAG = "DataLogger"

--- a/datalogger/src/main/java/org/obd/graphs/bl/datalogger/DataLoggerService.kt
+++ b/datalogger/src/main/java/org/obd/graphs/bl/datalogger/DataLoggerService.kt
@@ -46,6 +46,8 @@ private const val ACTION_STOP = "org.obd.graphs.logger.STOP"
 private const val UPDATE_QUERY = "org.obd.graphs.logger.UPDATE_QUERY"
 private const val QUERY = "org.obd.graphs.logger.QUERY"
 private const val EXECUTE_ROUTINE = "org.obd.graphs.logger.EXECUTE_ROUTINE"
+private const val ACTION_MODULE_DISCOVERY = "org.obd.graphs.logger.MODULE_DISCOVERY"
+private const val MODULE_DISCOVERY_HEADER = "org.obd.graphs.logger.MODULE_DISCOVERY.header"
 
 class DataLoggerService : Service() {
     private val binder = LocalBinder()
@@ -102,6 +104,12 @@ class DataLoggerService : Service() {
                 query?.let { DataLoggerRepository.workflowOrchestrator.executeRoutine(it) }
             }
 
+            ACTION_MODULE_DISCOVERY -> {
+                intent.getStringExtra(MODULE_DISCOVERY_HEADER)?.let {
+                    DataLoggerRepository.workflowOrchestrator.discoverModule(it)
+                }
+            }
+
             ACTION_STOP -> {
                 DataLoggerRepository.workflowOrchestrator.stop()
                 serviceStop()
@@ -147,6 +155,10 @@ class DataLoggerService : Service() {
 
     fun scheduleDTCRead(selectedModules: Set<String> = emptySet()) {
         enqueueWork(ACTION_DTC_READ) { it.putStringArrayListExtra(DTC_SELECTED_MODULES, ArrayList(selectedModules)) }
+    }
+
+    fun discoverModule(header: String) {
+        enqueueWork(ACTION_MODULE_DISCOVERY) { it.putExtra(MODULE_DISCOVERY_HEADER, header) }
     }
 
     fun stop() {

--- a/datalogger/src/main/java/org/obd/graphs/bl/datalogger/ModuleDiscoveryResult.kt
+++ b/datalogger/src/main/java/org/obd/graphs/bl/datalogger/ModuleDiscoveryResult.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.bl.datalogger
+
+import java.io.Serializable
+
+data class ModuleDiscoveryResult(
+    val header: String,
+    val found: Boolean
+) : Serializable

--- a/datalogger/src/main/java/org/obd/graphs/bl/datalogger/WorkflowOrchestrator.kt
+++ b/datalogger/src/main/java/org/obd/graphs/bl/datalogger/WorkflowOrchestrator.kt
@@ -114,6 +114,20 @@ internal class WorkflowOrchestrator internal constructor() {
             sendBroadcastEvent(event)
         }
 
+        override fun onModuleDiscovered(
+            header: String,
+            status: ModuleDiscoveryStatus
+        ) {
+            if (Log.isLoggable(LOG_TAG, Log.DEBUG)) {
+                Log.d(LOG_TAG, "Received onModuleDiscovered event. Header: $header, status: $status")
+            }
+
+            sendBroadcastEvent(
+                MODULE_DISCOVERY_RESULT_EVENT,
+                ModuleDiscoveryResult(header = header, found = status == ModuleDiscoveryStatus.FOUND)
+            )
+        }
+
         override fun onRunning(vehicleCapabilities: VehicleCapabilities) {
             if (Log.isLoggable(LOG_TAG, Log.DEBUG)) {
                 Log.d(LOG_TAG, "Received onRunning event. We are connected to the vehicle: $vehicleCapabilities")
@@ -253,6 +267,11 @@ internal class WorkflowOrchestrator internal constructor() {
         DiagnosticRequestIDManager.getMappings()
             .filter { it.headerValue.isNotEmpty() && it.requestKey in selectedModules }
             .map { Init.Header.builder().mode(it.displayName).header(it.headerValue).build() }
+
+    fun discoverModule(header: String) {
+        val result = workflow.discoverModule(header)
+        Log.i(LOG_TAG, "Module discovery for header=$header scheduled: $result")
+    }
 
     fun executeRoutine(query: Query) {
         currentQuery = query

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-obdMetricVersion=11.25.0-SNAPSHOT
+obdMetricVersion=11.26.0-SNAPSHOT


### PR DESCRIPTION
…overy

Adds two independent, UDS-safety-oriented features inspired by reviewing StelvioOBD's risk-assessment notes and its discover_ecus.py tool.

Risky-mode save guardrail: EditPidBottomSheet's mode field is free text, so a user could previously save a custom PID with UDS mode 04 (clear DTCs), 08 (component/actuator control), 2E (write data by identifier) or 31 (routine control) with no warning at all. These modes can permanently alter ECU configuration or actuate hardware on a real vehicle. Saving now checks the chosen mode against a small risky-modes map and, if matched, shows a confirmation dialog with the specific reason before persisting; anything else keeps saving immediately as before.

ECU module auto-discovery: every Diagnostic Request ID (DRI) entry used by multi-module DTC scanning previously had to be typed in by hand. This adds a sweep dialog, reachable from a new FAB on the DRI screen, that probes a configurable range of candidate CAN headers with a UDS TesterPresent (3E00) request and lets the user add whichever headers answer as new, unnamed DRI entries to be renamed afterward through the existing edit UI. The probe is dispatched through DataLoggerService/WorkflowOrchestrator the same way routines and DTC actions already are, and results are delivered back to the fragment via a broadcast event carrying a ModuleDiscoveryResult payload. This app-side change depends on the new discoverModule API added to obd-metrics 11.26.0-SNAPSHOT in a companion commit on that repo (which also fixes a bug where ObdCommandHandler silently dropped empty/NO_DATA replies for any command other than RoutineCommand, which would otherwise have prevented "not found" probes from ever reporting back).

Verified via full app build: :datalogger:compileDebugKotlin, :app:compileGiuliaDebugKotlin, spotlessApply, and :app:assembleGiuliaDebug all pass. Not verified against real hardware in this environment - the 7E00 success-code assumption and default DA..F1 header convention follow the existing bundled profile files and the StelvioOBD reference tool, but have not been confirmed against a live adapter/vehicle.