### PR TITLE
feat: group PID picker by category, consolidate selected PIDs

### DIFF
--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidCategory.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidCategory.kt
@@ -20,17 +20,17 @@ import org.obd.graphs.R
 import org.obd.graphs.bl.datalogger.isUserCustom
 import org.obd.metrics.pid.PidDefinition
 
-enum class PidCategory(val stringRes: Int) {
-    BASICS(R.string.pref_pid_manage_dialog_category_basics),
-    IGNITION(R.string.pref_pid_manage_dialog_category_ignition),
-    FUEL_AFR(R.string.pref_pid_manage_dialog_category_fuel_afr),
-    BOOST(R.string.pref_pid_manage_dialog_category_boost),
-    LOAD_TORQUE(R.string.pref_pid_manage_dialog_category_load_torque),
-    TEMPERATURE(R.string.pref_pid_manage_dialog_category_temperature),
-    AIR_INTAKE(R.string.pref_pid_manage_dialog_category_air_intake),
-    ELECTRICAL(R.string.pref_pid_manage_dialog_category_electrical),
-    LOCATION(R.string.pref_pid_manage_dialog_category_location),
-    OTHER(R.string.pref_pid_manage_dialog_category_other)
+enum class PidCategory(val stringRes: Int, val shortStringRes: Int) {
+    BASICS(R.string.pref_pid_manage_dialog_category_basics, R.string.pref_pid_manage_dialog_category_basics_short),
+    IGNITION(R.string.pref_pid_manage_dialog_category_ignition, R.string.pref_pid_manage_dialog_category_ignition_short),
+    FUEL_AFR(R.string.pref_pid_manage_dialog_category_fuel_afr, R.string.pref_pid_manage_dialog_category_fuel_afr_short),
+    BOOST(R.string.pref_pid_manage_dialog_category_boost, R.string.pref_pid_manage_dialog_category_boost_short),
+    LOAD_TORQUE(R.string.pref_pid_manage_dialog_category_load_torque, R.string.pref_pid_manage_dialog_category_load_torque_short),
+    TEMPERATURE(R.string.pref_pid_manage_dialog_category_temperature, R.string.pref_pid_manage_dialog_category_temperature_short),
+    AIR_INTAKE(R.string.pref_pid_manage_dialog_category_air_intake, R.string.pref_pid_manage_dialog_category_air_intake_short),
+    ELECTRICAL(R.string.pref_pid_manage_dialog_category_electrical, R.string.pref_pid_manage_dialog_category_electrical_short),
+    LOCATION(R.string.pref_pid_manage_dialog_category_location, R.string.pref_pid_manage_dialog_category_location_short),
+    OTHER(R.string.pref_pid_manage_dialog_category_other, R.string.pref_pid_manage_dialog_category_other_short)
 }
 
 // Order in which categories are grouped/sorted when browsing PIDs -- distinct from RULES below,

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidCategory.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidCategory.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019-2026, Tomasz Żebrowski
+ *
+ * <p>Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.obd.graphs.preferences.pid
+
+import org.obd.graphs.R
+import org.obd.graphs.bl.datalogger.isUserCustom
+import org.obd.metrics.pid.PidDefinition
+
+enum class PidCategory(val stringRes: Int) {
+    BASICS(R.string.pref_pid_manage_dialog_category_basics),
+    IGNITION(R.string.pref_pid_manage_dialog_category_ignition),
+    FUEL_AFR(R.string.pref_pid_manage_dialog_category_fuel_afr),
+    BOOST(R.string.pref_pid_manage_dialog_category_boost),
+    LOAD_TORQUE(R.string.pref_pid_manage_dialog_category_load_torque),
+    TEMPERATURE(R.string.pref_pid_manage_dialog_category_temperature),
+    AIR_INTAKE(R.string.pref_pid_manage_dialog_category_air_intake),
+    ELECTRICAL(R.string.pref_pid_manage_dialog_category_electrical),
+    LOCATION(R.string.pref_pid_manage_dialog_category_location),
+    OTHER(R.string.pref_pid_manage_dialog_category_other)
+}
+
+// Order in which categories are grouped/sorted when browsing PIDs -- distinct from RULES below,
+// which is match-priority order (most-specific keyword wins).
+val PID_CATEGORY_DISPLAY_ORDER: List<PidCategory> = listOf(
+    PidCategory.BASICS,
+    PidCategory.IGNITION,
+    PidCategory.FUEL_AFR,
+    PidCategory.BOOST,
+    PidCategory.LOAD_TORQUE,
+    PidCategory.TEMPERATURE,
+    PidCategory.AIR_INTAKE,
+    PidCategory.ELECTRICAL,
+    PidCategory.LOCATION,
+    PidCategory.OTHER
+)
+
+private data class CategoryRule(val category: PidCategory, val pattern: Regex)
+
+// Ordered most-specific first, e.g. "O2 Voltage" must match FUEL_AFR before the generic
+// "voltage" keyword in ELECTRICAL, and "Calculated horse power" must match LOAD_TORQUE.
+private val RULES: List<CategoryRule> = listOf(
+    CategoryRule(PidCategory.IGNITION, Regex("spark|ignition|timing adv|misfire", RegexOption.IGNORE_CASE)),
+    CategoryRule(PidCategory.FUEL_AFR, Regex("\\bafr\\b|lambda|fuel|air.?fuel|\\bo2\\b|oxygen", RegexOption.IGNORE_CASE)),
+    CategoryRule(
+        PidCategory.BOOST,
+        Regex("boost|wastegate|turbo|manifold|intake pressure|\\bmap\\b|atmospheric|baro", RegexOption.IGNORE_CASE)
+    ),
+    CategoryRule(PidCategory.LOAD_TORQUE, Regex("torque|\\bload\\b|horsepower|horse power|\\bhp\\b", RegexOption.IGNORE_CASE)),
+    CategoryRule(PidCategory.TEMPERATURE, Regex("temp", RegexOption.IGNORE_CASE)),
+    CategoryRule(PidCategory.AIR_INTAKE, Regex("\\bair\\b|\\bmaf\\b|flow", RegexOption.IGNORE_CASE)),
+    CategoryRule(PidCategory.ELECTRICAL, Regex("voltage|battery|\\bibs\\b|oil level|oil degradation", RegexOption.IGNORE_CASE)),
+    CategoryRule(PidCategory.LOCATION, Regex("latitude|longitude|\\blat\\b|\\blon\\b|\\blng\\b|gps", RegexOption.IGNORE_CASE)),
+    CategoryRule(PidCategory.BASICS, Regex("speed|\\brpm\\b|pedal|throttle|gear|selector|distance|odometer", RegexOption.IGNORE_CASE))
+)
+
+// No upstream category field exists on PidDefinition (nor in the ObdMetrics JSON source), so
+// categorization is inferred from the PID's description text, same approach as the web log
+// viewer's signal-categories.ts.
+fun categoryFor(pid: PidDefinition): PidCategory {
+    val text = "${pid.description ?: ""} ${pid.longDescription ?: ""}"
+    for (rule in RULES) {
+        if (rule.pattern.containsMatchIn(text)) return rule.category
+    }
+    return PidCategory.OTHER
+}
+
+// The grouping a PID header row falls under in the picker list: every checked (selected)
+// standard PID is collected into a single Selected group regardless of its category, while
+// unchecked ones are grouped by their actual category. Custom (user-added) PIDs have no section.
+sealed class PidSection {
+    object Selected : PidSection()
+    data class Category(val category: PidCategory) : PidSection()
+}
+
+fun sectionFor(item: PidDefinitionDetails): PidSection? = when {
+    item.source.isUserCustom -> null
+    item.checked -> PidSection.Selected
+    else -> PidSection.Category(categoryFor(item.source))
+}

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -153,7 +153,7 @@ open class PidDefinitionDialogFragment(
     // on top of it, so the bar never covers the PID checkboxes/text underneath.
     private fun setRecyclerViewIndexBarInset(reserved: Boolean) {
         val marginPx = if (reserved) {
-            TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 36f, resources.displayMetrics).toInt()
+            TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48f, resources.displayMetrics).toInt()
         } else {
             0
         }
@@ -165,16 +165,23 @@ open class PidDefinitionDialogFragment(
         }
     }
 
+    // Markers are square (matching the bar's own width) so the -90 rotation needed for vertical
+    // text doesn't make the drawn text spill outside its own bounds, and the box is tall enough
+    // to be a comfortable tap target -- the previous single-line horizontal abbreviation was too
+    // short vertically to hit reliably.
     private fun createIndexMarker(label: String, targetPosition: Int): TextView {
-        val paddingPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4f, resources.displayMetrics).toInt()
+        val sizePx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 40f, resources.displayMetrics).toInt()
         return TextView(requireContext()).apply {
             text = label
-            textSize = 9f
+            textSize = 11f
             setTypeface(typeface, Typeface.BOLD)
             setTextColor(Color.WHITE)
             gravity = Gravity.CENTER
-            setPadding(paddingPx, paddingPx, paddingPx, paddingPx)
-            layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+            rotation = -90f
+            layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, sizePx).apply {
+                val marginPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2f, resources.displayMetrics).toInt()
+                bottomMargin = marginPx
+            }
             setOnClickListener {
                 (recyclerView.layoutManager as? GridLayoutManager)?.scrollToPositionWithOffset(targetPosition, 0)
             }

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -76,7 +76,8 @@ open class PidDefinitionDialogFragment(
             data = emptyList(),
             editModeEnabled = dialogMode.isInteractive,
             onEditClicked = { clickedPid -> showEditBottomSheet(clickedPid) },
-            onDeleteClicked = { clickedPid -> viewModel.delete(clickedPid) }
+            onDeleteClicked = { clickedPid -> viewModel.delete(clickedPid) },
+            onCategoryToggled = { category, checked -> viewModel.setCategoryChecked(category, checked) }
         )
 
         recyclerView = root.findViewById(R.id.recycler_view)

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -18,7 +18,9 @@ package org.obd.graphs.preferences.pid
 
 import android.content.Context
 import android.content.res.Configuration
+import android.graphics.Color
 import android.graphics.Typeface
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.Gravity
@@ -61,6 +63,8 @@ open class PidDefinitionDialogFragment(
     private lateinit var categoryIndexBar: LinearLayout
     private lateinit var toolbarCard: View
     private lateinit var bottomPanelCard: View
+    private var indexMarkers: List<IndexMarker> = emptyList()
+    private var activeIndexMarker: IndexMarker? = null
 
     private val dialogMode: PidDefinitionDialogMode = PidDefinitionDialogMode.fromString(source)
     private val viewModel: PidDefinitionViewModel by viewModels {
@@ -105,6 +109,14 @@ open class PidDefinitionDialogFragment(
         // This keeps re-checking and self-corrects until it converges, however many passes it takes.
         toolbarCard.viewTreeObserver.addOnGlobalLayoutListener { syncRecyclerViewToToolbarEdges() }
 
+        // Highlights whichever group marker corresponds to what's currently scrolled into view,
+        // so the index bar also works as a "you are here" indicator, not just a jump target.
+        recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(rv: RecyclerView, dx: Int, dy: Int) {
+                updateActiveIndexMarker()
+            }
+        })
+
         attachSearchView()
         if (dragReorderEnabled) {
             attachDragManager(recyclerView)
@@ -143,23 +155,62 @@ open class PidDefinitionDialogFragment(
         }
 
         categoryIndexBar.removeAllViews()
+        activeIndexMarker = null
 
         if (anchors.size < 2) {
             categoryIndexBar.visibility = View.GONE
+            indexMarkers = emptyList()
             setContentIndexBarInset(reserved = false)
             return
         }
 
         categoryIndexBar.visibility = View.VISIBLE
         setContentIndexBarInset(reserved = true)
-        anchors.forEach { (section, position) ->
+        indexMarkers = anchors.map { (section, position) ->
             val label = when (section) {
                 is PidSection.Selected -> getString(R.string.pref_pid_manage_dialog_selected_pids_short)
                 is PidSection.Category -> getString(section.category.shortStringRes)
             }
-            categoryIndexBar.addView(createIndexMarker(label, position))
+            val marker = createIndexMarker(label, position)
+            categoryIndexBar.addView(marker.container)
+            marker
+        }
+        updateActiveIndexMarker()
+    }
+
+    // Finds whichever marker's group the currently-first-visible PID card belongs to and
+    // highlights it, clearing the highlight from whatever was previously active.
+    private fun updateActiveIndexMarker() {
+        if (indexMarkers.isEmpty()) return
+        val layoutManager = recyclerView.layoutManager as? GridLayoutManager ?: return
+        val firstVisible = layoutManager.findFirstVisibleItemPosition()
+        if (firstVisible == RecyclerView.NO_POSITION) return
+
+        val current = indexMarkers.lastOrNull { it.position <= firstVisible } ?: indexMarkers.first()
+        if (current === activeIndexMarker) return
+
+        activeIndexMarker?.let { setIndexMarkerHighlighted(it, false) }
+        setIndexMarkerHighlighted(current, true)
+        activeIndexMarker = current
+    }
+
+    private fun setIndexMarkerHighlighted(marker: IndexMarker, highlighted: Boolean) {
+        if (highlighted) {
+            marker.container.background = GradientDrawable().apply {
+                shape = GradientDrawable.RECTANGLE
+                cornerRadius = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, resources.displayMetrics)
+                setColor(androidx.core.content.ContextCompat.getColor(requireContext(), R.color.philippine_green))
+            }
+            marker.label.setTextColor(Color.WHITE)
+        } else {
+            val outValue = TypedValue()
+            requireContext().theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, outValue, true)
+            marker.container.setBackgroundResource(outValue.resourceId)
+            marker.label.setTextColor(androidx.core.content.ContextCompat.getColor(requireContext(), R.color.dialog_text_primary))
         }
     }
+
+    private data class IndexMarker(val position: Int, val container: FrameLayout, val label: TextView)
 
     // The toolbar (search bar) and button row get pushed right by the same amount while the
     // index bar is showing, so it gets its own real column instead of floating on top of card
@@ -207,7 +258,7 @@ open class PidDefinitionDialogFragment(
     // The rotated text is drawn via a TextView whose *unrotated* width/height are swapped
     // relative to the marker's real (rotated) footprint, centered inside a same-sized container --
     // that's what keeps the rotated glyphs aligned inside their own marker instead of drifting.
-    private fun createIndexMarker(label: String, targetPosition: Int): View {
+    private fun createIndexMarker(label: String, targetPosition: Int): IndexMarker {
         val thicknessPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 22f, resources.displayMetrics).toInt()
         val lengthPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 40f, resources.displayMetrics).toInt()
         val spacingPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 10f, resources.displayMetrics).toInt()
@@ -222,7 +273,7 @@ open class PidDefinitionDialogFragment(
             layoutParams = FrameLayout.LayoutParams(lengthPx, thicknessPx, Gravity.CENTER)
         }
 
-        return FrameLayout(requireContext()).apply {
+        val container = FrameLayout(requireContext()).apply {
             clipChildren = false
             addView(labelView)
             layoutParams = LinearLayout.LayoutParams(thicknessPx, lengthPx).apply { bottomMargin = spacingPx }
@@ -233,6 +284,8 @@ open class PidDefinitionDialogFragment(
                 (recyclerView.layoutManager as? GridLayoutManager)?.scrollToPositionWithOffset(targetPosition, 0)
             }
         }
+
+        return IndexMarker(targetPosition, container, labelView)
     }
 
     private fun showAddBottomSheet() {

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -28,6 +28,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
+import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -133,16 +134,34 @@ open class PidDefinitionDialogFragment(
 
         if (anchors.size < 2) {
             categoryIndexBar.visibility = View.GONE
+            setRecyclerViewIndexBarInset(reserved = false)
             return
         }
 
         categoryIndexBar.visibility = View.VISIBLE
+        setRecyclerViewIndexBarInset(reserved = true)
         anchors.forEach { (section, position) ->
             val label = when (section) {
                 is PidSection.Selected -> getString(R.string.pref_pid_manage_dialog_selected_pids_short)
                 is PidSection.Category -> getString(section.category.shortStringRes)
             }
             categoryIndexBar.addView(createIndexMarker(label, position))
+        }
+    }
+
+    // The list itself gets pushed to the right of the index bar rather than having the bar float
+    // on top of it, so the bar never covers the PID checkboxes/text underneath.
+    private fun setRecyclerViewIndexBarInset(reserved: Boolean) {
+        val marginPx = if (reserved) {
+            TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 36f, resources.displayMetrics).toInt()
+        } else {
+            0
+        }
+        (recyclerView.layoutParams as? RelativeLayout.LayoutParams)?.let {
+            if (it.marginStart != marginPx) {
+                it.marginStart = marginPx
+                recyclerView.layoutParams = it
+            }
         }
     }
 

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -29,6 +29,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -59,6 +60,8 @@ open class PidDefinitionDialogFragment(
     private lateinit var recyclerView: RecyclerView
     private lateinit var root: View
     private lateinit var categoryIndexBar: LinearLayout
+    private lateinit var toolbarCard: View
+    private lateinit var bottomPanelCard: View
 
     private val dialogMode: PidDefinitionDialogMode = PidDefinitionDialogMode.fromString(source)
     private val viewModel: PidDefinitionViewModel by viewModels {
@@ -92,6 +95,8 @@ open class PidDefinitionDialogFragment(
         recyclerView.adapter = adapter
 
         categoryIndexBar = root.findViewById(R.id.category_index_bar)
+        toolbarCard = root.findViewById(R.id.toolbar_card)
+        bottomPanelCard = root.findViewById(R.id.bottom_panel_card)
 
         attachSearchView()
         if (dragReorderEnabled) {
@@ -134,10 +139,12 @@ open class PidDefinitionDialogFragment(
 
         if (anchors.size < 2) {
             categoryIndexBar.visibility = View.GONE
+            setContentIndexBarInset(reserved = false)
             return
         }
 
         categoryIndexBar.visibility = View.VISIBLE
+        setContentIndexBarInset(reserved = true)
         anchors.forEach { (section, position) ->
             val label = when (section) {
                 is PidSection.Selected -> getString(R.string.pref_pid_manage_dialog_selected_pids_short)
@@ -147,10 +154,31 @@ open class PidDefinitionDialogFragment(
         }
     }
 
-    // A transparent overlay, not a real layout column -- the list keeps its full width (matching
-    // the search bar above it) instead of being squeezed to make room for this. Each marker is
-    // thin (18dp) so it sits in the sliver of card surface before the checkbox rather than on top
-    // of it. The rotated text is drawn via a TextView whose *unrotated* width/height are swapped
+    // The toolbar (search bar), list, and button row all get pushed right by the same visual
+    // amount while the index bar is showing, so it gets its own real column instead of floating
+    // on top of card content -- and the three stay aligned with each other either way, they just
+    // share less of the screen while the bar needs room. The RecyclerView itself carries no
+    // horizontal margin (its PID cards each already have their own 8dp margin), unlike the
+    // toolbar/button cards which get theirs directly -- so its reserved inset is offset by that
+    // 8dp to keep all three edges lined up.
+    private fun setContentIndexBarInset(reserved: Boolean) {
+        fun dp(value: Float) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value, resources.displayMetrics).toInt()
+
+        applyMarginStart(toolbarCard, dp(if (reserved) 32f else 8f))
+        applyMarginStart(bottomPanelCard, dp(if (reserved) 32f else 8f))
+        applyMarginStart(recyclerView, dp(if (reserved) 24f else 0f))
+    }
+
+    private fun applyMarginStart(view: View, marginPx: Int) {
+        (view.layoutParams as? RelativeLayout.LayoutParams)?.let {
+            if (it.marginStart != marginPx) {
+                it.marginStart = marginPx
+                view.layoutParams = it
+            }
+        }
+    }
+
+    // The rotated text is drawn via a TextView whose *unrotated* width/height are swapped
     // relative to the marker's real (rotated) footprint, centered inside a same-sized container --
     // that's what keeps the rotated glyphs aligned inside their own marker instead of drifting.
     private fun createIndexMarker(label: String, targetPosition: Int): View {

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -27,8 +27,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.FrameLayout
 import android.widget.LinearLayout
-import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -134,12 +134,10 @@ open class PidDefinitionDialogFragment(
 
         if (anchors.size < 2) {
             categoryIndexBar.visibility = View.GONE
-            setRecyclerViewIndexBarInset(reserved = false)
             return
         }
 
         categoryIndexBar.visibility = View.VISIBLE
-        setRecyclerViewIndexBarInset(reserved = true)
         anchors.forEach { (section, position) ->
             val label = when (section) {
                 is PidSection.Selected -> getString(R.string.pref_pid_manage_dialog_selected_pids_short)
@@ -149,39 +147,33 @@ open class PidDefinitionDialogFragment(
         }
     }
 
-    // The list itself gets pushed to the right of the index bar rather than having the bar float
-    // on top of it, so the bar never covers the PID checkboxes/text underneath.
-    private fun setRecyclerViewIndexBarInset(reserved: Boolean) {
-        val marginPx = if (reserved) {
-            TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48f, resources.displayMetrics).toInt()
-        } else {
-            0
-        }
-        (recyclerView.layoutParams as? RelativeLayout.LayoutParams)?.let {
-            if (it.marginStart != marginPx) {
-                it.marginStart = marginPx
-                recyclerView.layoutParams = it
-            }
-        }
-    }
+    // A transparent overlay, not a real layout column -- the list keeps its full width (matching
+    // the search bar above it) instead of being squeezed to make room for this. Each marker is
+    // thin (18dp) so it sits in the sliver of card surface before the checkbox rather than on top
+    // of it. The rotated text is drawn via a TextView whose *unrotated* width/height are swapped
+    // relative to the marker's real (rotated) footprint, centered inside a same-sized container --
+    // that's what keeps the rotated glyphs aligned inside their own marker instead of drifting.
+    private fun createIndexMarker(label: String, targetPosition: Int): View {
+        val thicknessPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 18f, resources.displayMetrics).toInt()
+        val lengthPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 34f, resources.displayMetrics).toInt()
 
-    // Markers are square (matching the bar's own width) so the -90 rotation needed for vertical
-    // text doesn't make the drawn text spill outside its own bounds, and the box is tall enough
-    // to be a comfortable tap target -- the previous single-line horizontal abbreviation was too
-    // short vertically to hit reliably.
-    private fun createIndexMarker(label: String, targetPosition: Int): TextView {
-        val sizePx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 40f, resources.displayMetrics).toInt()
-        return TextView(requireContext()).apply {
+        val labelView = TextView(requireContext()).apply {
             text = label
-            textSize = 11f
+            textSize = 9f
             setTypeface(typeface, Typeface.BOLD)
             setTextColor(Color.WHITE)
             gravity = Gravity.CENTER
             rotation = -90f
-            layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, sizePx).apply {
-                val marginPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2f, resources.displayMetrics).toInt()
-                bottomMargin = marginPx
-            }
+            layoutParams = FrameLayout.LayoutParams(lengthPx, thicknessPx, Gravity.CENTER)
+        }
+
+        return FrameLayout(requireContext()).apply {
+            clipChildren = false
+            addView(labelView)
+            layoutParams = LinearLayout.LayoutParams(thicknessPx, lengthPx)
+            val outValue = TypedValue()
+            requireContext().theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, outValue, true)
+            setBackgroundResource(outValue.resourceId)
             setOnClickListener {
                 (recyclerView.layoutManager as? GridLayoutManager)?.scrollToPositionWithOffset(targetPosition, 0)
             }

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -18,12 +18,17 @@ package org.obd.graphs.preferences.pid
 
 import android.content.Context
 import android.content.res.Configuration
+import android.graphics.Color
+import android.graphics.Typeface
 import android.os.Bundle
 import android.util.TypedValue
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.viewModels
@@ -52,6 +57,7 @@ open class PidDefinitionDialogFragment(
 
     private lateinit var recyclerView: RecyclerView
     private lateinit var root: View
+    private lateinit var categoryIndexBar: LinearLayout
 
     private val dialogMode: PidDefinitionDialogMode = PidDefinitionDialogMode.fromString(source)
     private val viewModel: PidDefinitionViewModel by viewModels {
@@ -84,6 +90,8 @@ open class PidDefinitionDialogFragment(
         recyclerView.layoutManager = GridLayoutManager(context, 1)
         recyclerView.adapter = adapter
 
+        categoryIndexBar = root.findViewById(R.id.category_index_bar)
+
         attachSearchView()
         if (dragReorderEnabled) {
             attachDragManager(recyclerView)
@@ -105,7 +113,51 @@ open class PidDefinitionDialogFragment(
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { state ->
                     adapter.updateData(state.filteredItems)
+                    updateCategoryIndexBar(state.filteredItems)
                 }
+            }
+        }
+    }
+
+    // A jump-to-group index along the left edge, so a long PID list doesn't require scrolling to
+    // find a specific category (or the Selected group) -- only shown once there's more than one
+    // group to jump between, and rebuilt whenever the visible group set changes (e.g. search).
+    private fun updateCategoryIndexBar(items: List<PidDefinitionDetails>) {
+        val anchors = LinkedHashMap<PidSection, Int>()
+        items.forEachIndexed { index, item ->
+            val section = sectionFor(item) ?: return@forEachIndexed
+            anchors.putIfAbsent(section, index)
+        }
+
+        categoryIndexBar.removeAllViews()
+
+        if (anchors.size < 2) {
+            categoryIndexBar.visibility = View.GONE
+            return
+        }
+
+        categoryIndexBar.visibility = View.VISIBLE
+        anchors.forEach { (section, position) ->
+            val label = when (section) {
+                is PidSection.Selected -> getString(R.string.pref_pid_manage_dialog_selected_pids_short)
+                is PidSection.Category -> getString(section.category.shortStringRes)
+            }
+            categoryIndexBar.addView(createIndexMarker(label, position))
+        }
+    }
+
+    private fun createIndexMarker(label: String, targetPosition: Int): TextView {
+        val paddingPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4f, resources.displayMetrics).toInt()
+        return TextView(requireContext()).apply {
+            text = label
+            textSize = 9f
+            setTypeface(typeface, Typeface.BOLD)
+            setTextColor(Color.WHITE)
+            gravity = Gravity.CENTER
+            setPadding(paddingPx, paddingPx, paddingPx, paddingPx)
+            layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+            setOnClickListener {
+                (recyclerView.layoutManager as? GridLayoutManager)?.scrollToPositionWithOffset(targetPosition, 0)
             }
         }
     }

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -33,6 +33,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -154,19 +155,32 @@ open class PidDefinitionDialogFragment(
         }
     }
 
-    // The toolbar (search bar), list, and button row all get pushed right by the same visual
-    // amount while the index bar is showing, so it gets its own real column instead of floating
-    // on top of card content -- and the three stay aligned with each other either way, they just
-    // share less of the screen while the bar needs room. The RecyclerView itself carries no
-    // horizontal margin (its PID cards each already have their own 8dp margin), unlike the
-    // toolbar/button cards which get theirs directly -- so its reserved inset is offset by that
-    // 8dp to keep all three edges lined up.
+    // The toolbar (search bar) and button row get pushed right by the same amount while the
+    // index bar is showing, so it gets its own real column instead of floating on top of card
+    // content -- only the start margin changes, so neither loses any width, they just move over.
+    // The RecyclerView's own margin is then derived from the toolbar's *actual rendered* edges
+    // once layout settles, rather than computed from theoretical dp math: this dialog's window
+    // is wrap-content-sized around its widest child, which does not leave the plain end-margin
+    // gap you'd expect, so dp arithmetic alone kept landing the PID cards (which carry their own
+    // 8dp margin, unlike the toolbar/button cards which get theirs directly) a few dp short of
+    // the toolbar's edges. Reading real positions sidesteps that instead of chasing it.
     private fun setContentIndexBarInset(reserved: Boolean) {
         fun dp(value: Float) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value, resources.displayMetrics).toInt()
+        val startPx = dp(if (reserved) 36f else 8f)
 
-        applyMarginStart(toolbarCard, dp(if (reserved) 32f else 8f))
-        applyMarginStart(bottomPanelCard, dp(if (reserved) 32f else 8f))
-        applyMarginStart(recyclerView, dp(if (reserved) 24f else 0f))
+        applyMarginStart(toolbarCard, startPx)
+        applyMarginStart(bottomPanelCard, startPx)
+
+        toolbarCard.doOnNextLayout {
+            val cardOwnMarginPx = dp(8f)
+            val targetLeft = toolbarCard.left - cardOwnMarginPx
+            val targetRight = toolbarCard.right + cardOwnMarginPx
+            (recyclerView.layoutParams as? RelativeLayout.LayoutParams)?.let {
+                it.leftMargin = targetLeft
+                it.rightMargin = root.width - targetRight
+                recyclerView.layoutParams = it
+            }
+        }
     }
 
     private fun applyMarginStart(view: View, marginPx: Int) {
@@ -182,12 +196,13 @@ open class PidDefinitionDialogFragment(
     // relative to the marker's real (rotated) footprint, centered inside a same-sized container --
     // that's what keeps the rotated glyphs aligned inside their own marker instead of drifting.
     private fun createIndexMarker(label: String, targetPosition: Int): View {
-        val thicknessPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 18f, resources.displayMetrics).toInt()
-        val lengthPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 34f, resources.displayMetrics).toInt()
+        val thicknessPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 22f, resources.displayMetrics).toInt()
+        val lengthPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 40f, resources.displayMetrics).toInt()
+        val spacingPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 10f, resources.displayMetrics).toInt()
 
         val labelView = TextView(requireContext()).apply {
             text = label
-            textSize = 9f
+            textSize = 12f
             setTypeface(typeface, Typeface.BOLD)
             setTextColor(Color.WHITE)
             gravity = Gravity.CENTER
@@ -198,7 +213,7 @@ open class PidDefinitionDialogFragment(
         return FrameLayout(requireContext()).apply {
             clipChildren = false
             addView(labelView)
-            layoutParams = LinearLayout.LayoutParams(thicknessPx, lengthPx)
+            layoutParams = LinearLayout.LayoutParams(thicknessPx, lengthPx).apply { bottomMargin = spacingPx }
             val outValue = TypedValue()
             requireContext().theme.resolveAttribute(android.R.attr.selectableItemBackgroundBorderless, outValue, true)
             setBackgroundResource(outValue.resourceId)

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -18,7 +18,6 @@ package org.obd.graphs.preferences.pid
 
 import android.content.Context
 import android.content.res.Configuration
-import android.graphics.Color
 import android.graphics.Typeface
 import android.os.Bundle
 import android.util.TypedValue
@@ -33,7 +32,6 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
-import androidx.core.view.doOnNextLayout
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -99,6 +97,14 @@ open class PidDefinitionDialogFragment(
         toolbarCard = root.findViewById(R.id.toolbar_card)
         bottomPanelCard = root.findViewById(R.id.bottom_panel_card)
 
+        // Keeps the RecyclerView's PID cards (which carry their own 8dp margin, unlike the
+        // toolbar/button cards which get theirs directly) aligned to the toolbar's *actual*
+        // rendered edges on every layout pass, not just once -- a one-shot post-layout callback
+        // here was a race against the several layout passes this dialog goes through as its
+        // content loads asynchronously, and could settle on a stale (pre-margin-change) position.
+        // This keeps re-checking and self-corrects until it converges, however many passes it takes.
+        toolbarCard.viewTreeObserver.addOnGlobalLayoutListener { syncRecyclerViewToToolbarEdges() }
+
         attachSearchView()
         if (dragReorderEnabled) {
             attachDragManager(recyclerView)
@@ -158,29 +164,15 @@ open class PidDefinitionDialogFragment(
     // The toolbar (search bar) and button row get pushed right by the same amount while the
     // index bar is showing, so it gets its own real column instead of floating on top of card
     // content -- only the start margin changes, so neither loses any width, they just move over.
-    // The RecyclerView's own margin is then derived from the toolbar's *actual rendered* edges
-    // once layout settles, rather than computed from theoretical dp math: this dialog's window
-    // is wrap-content-sized around its widest child, which does not leave the plain end-margin
-    // gap you'd expect, so dp arithmetic alone kept landing the PID cards (which carry their own
-    // 8dp margin, unlike the toolbar/button cards which get theirs directly) a few dp short of
-    // the toolbar's edges. Reading real positions sidesteps that instead of chasing it.
+    // The RecyclerView's own margin is kept in sync separately (see
+    // syncRecyclerViewToToolbarEdges), since dp arithmetic alone doesn't reliably predict where
+    // the toolbar ends up in this wrap-content-sized dialog window.
     private fun setContentIndexBarInset(reserved: Boolean) {
         fun dp(value: Float) = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value, resources.displayMetrics).toInt()
         val startPx = dp(if (reserved) 36f else 8f)
 
         applyMarginStart(toolbarCard, startPx)
         applyMarginStart(bottomPanelCard, startPx)
-
-        toolbarCard.doOnNextLayout {
-            val cardOwnMarginPx = dp(8f)
-            val targetLeft = toolbarCard.left - cardOwnMarginPx
-            val targetRight = toolbarCard.right + cardOwnMarginPx
-            (recyclerView.layoutParams as? RelativeLayout.LayoutParams)?.let {
-                it.leftMargin = targetLeft
-                it.rightMargin = root.width - targetRight
-                recyclerView.layoutParams = it
-            }
-        }
     }
 
     private fun applyMarginStart(view: View, marginPx: Int) {
@@ -188,6 +180,26 @@ open class PidDefinitionDialogFragment(
             if (it.marginStart != marginPx) {
                 it.marginStart = marginPx
                 view.layoutParams = it
+            }
+        }
+    }
+
+    // Aligns the RecyclerView's PID cards (which carry their own 8dp margin, unlike the
+    // toolbar/button cards which get theirs directly from the layout) to the toolbar's *actual
+    // rendered* edges, re-checked on every layout pass rather than assumed from dp math -- this
+    // dialog's wrap-content-sized window doesn't leave the plain end-margin gap dp arithmetic
+    // expects, and the toolbar's margin can go through several passes as content loads
+    // asynchronously, so this keeps re-syncing until it settles instead of guessing once.
+    private fun syncRecyclerViewToToolbarEdges() {
+        val cardOwnMarginPx = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 8f, resources.displayMetrics).toInt()
+        val targetLeft = toolbarCard.left - cardOwnMarginPx
+        val targetRight = toolbarCard.right + cardOwnMarginPx
+        (recyclerView.layoutParams as? RelativeLayout.LayoutParams)?.let {
+            val targetRightMargin = root.width - targetRight
+            if (it.leftMargin != targetLeft || it.rightMargin != targetRightMargin) {
+                it.leftMargin = targetLeft
+                it.rightMargin = targetRightMargin
+                recyclerView.layoutParams = it
             }
         }
     }
@@ -204,7 +216,7 @@ open class PidDefinitionDialogFragment(
             text = label
             textSize = 12f
             setTypeface(typeface, Typeface.BOLD)
-            setTextColor(Color.WHITE)
+            setTextColor(androidx.core.content.ContextCompat.getColor(requireContext(), R.color.dialog_text_primary))
             gravity = Gravity.CENTER
             rotation = -90f
             layoutParams = FrameLayout.LayoutParams(lengthPx, thicknessPx, Gravity.CENTER)

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewAdapter.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewAdapter.kt
@@ -27,6 +27,7 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.checkbox.MaterialCheckBox
 import org.obd.graphs.R
 import org.obd.graphs.bl.datalogger.isUserCustom
 import org.obd.graphs.ui.common.COLOR_DYNAMIC_SELECTOR_SPORT
@@ -40,7 +41,8 @@ class PidDefinitionViewAdapter internal constructor(
     var data: List<PidDefinitionDetails>,
     private val editModeEnabled: Boolean,
     private val onEditClicked: (PidDefinitionDetails) -> Unit,
-    private val onDeleteClicked: (PidDefinitionDetails) -> Unit
+    private val onDeleteClicked: (PidDefinitionDetails) -> Unit,
+    private val onCategoryToggled: (PidCategory, Boolean) -> Unit = { _, _ -> }
 ) : RecyclerView.Adapter<PidDefinitionViewAdapter.ViewHolder>() {
 
     private val inflater: LayoutInflater = LayoutInflater.from(context)
@@ -56,14 +58,54 @@ class PidDefinitionViewAdapter internal constructor(
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = data[position]
+        val previousItem = if (position > 0) data[position - 1] else null
 
-        val isSystemPid = !item.source.isUserCustom
-        val previousWasCustom = position > 0 && data[position - 1].source.isUserCustom
+        // Checked PIDs are always collected under one "Selected" header, regardless of category,
+        // so they read as a single group -- only the unchecked/browsable PIDs below get their own
+        // per-category headers. Checked PIDs still keep their own custom drag order within that
+        // one group (see sortItems).
+        val section = sectionFor(item)
+        val previousSection = previousItem?.let { sectionFor(it) }
 
-        if (isSystemPid && previousWasCustom) {
-            holder.separator.visibility = View.VISIBLE
-        } else {
-            holder.separator.visibility = View.GONE
+        when {
+            section != null && section != previousSection -> {
+                holder.separatorContainer.visibility = View.VISIBLE
+
+                when (section) {
+                    is PidSection.Selected -> {
+                        holder.separator.text = context?.getString(R.string.pref_pid_manage_dialog_selected_pids)
+                        holder.categorySelect.visibility = View.GONE
+                        holder.categorySelect.setOnClickListener(null)
+                    }
+                    is PidSection.Category -> {
+                        val category = section.category
+                        holder.separator.text = context?.getString(category.stringRes) ?: category.name
+
+                        if (editModeEnabled) {
+                            holder.categorySelect.visibility = View.GONE
+                            holder.categorySelect.setOnClickListener(null)
+                        } else {
+                            holder.categorySelect.visibility = View.VISIBLE
+                            val categoryItems = data.filter { !it.source.isUserCustom && categoryFor(it.source) == category }
+                            val checkedCount = categoryItems.count { it.checked }
+                            val allChecked = checkedCount > 0 && checkedCount == categoryItems.size
+
+                            holder.categorySelect.checkedState = when {
+                                checkedCount == 0 -> MaterialCheckBox.STATE_UNCHECKED
+                                allChecked -> MaterialCheckBox.STATE_CHECKED
+                                else -> MaterialCheckBox.STATE_INDETERMINATE
+                            }
+                            holder.categorySelect.setOnClickListener {
+                                onCategoryToggled(category, !allChecked)
+                            }
+                        }
+                    }
+                }
+            }
+            else -> {
+                holder.separatorContainer.visibility = View.GONE
+                holder.categorySelect.setOnClickListener(null)
+            }
         }
 
         item.run {
@@ -151,7 +193,9 @@ class PidDefinitionViewAdapter internal constructor(
     override fun getItemCount(): Int = data.size
 
     inner class ViewHolder(binding: View) : RecyclerView.ViewHolder(binding) {
+        val separatorContainer: View = binding.findViewById(R.id.separator_container)
         val separator: TextView = binding.findViewById(R.id.tv_separator)
+        val categorySelect: MaterialCheckBox = binding.findViewById(R.id.category_selected)
         val module: TextView = binding.findViewById(R.id.pid_module)
         val description: TextView = binding.findViewById(R.id.pid_description)
         val longDescription: TextView = binding.findViewById(R.id.pid_long_description)

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewModel.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewModel.kt
@@ -104,10 +104,28 @@ class PidDefinitionViewModel(
     fun toggleSelectAll(selectAll: Boolean) {
         viewModelScope.launch(Dispatchers.Default) {
             allMasterItems.forEach { it.checked = selectAll }
-            val updated = applyFilter(allMasterItems, _uiState.value.searchQuery)
+            val filtered = applyFilter(allMasterItems, _uiState.value.searchQuery)
+            val sortedAndFiltered = sortItems(filtered)
             _uiState.value = _uiState.value.copy(
                 items = ArrayList(allMasterItems),
-                filteredItems = ArrayList(updated),
+                filteredItems = ArrayList(sortedAndFiltered),
+                lastUpdate = System.currentTimeMillis()
+            )
+        }
+    }
+
+    fun setCategoryChecked(category: PidCategory, checked: Boolean) {
+        viewModelScope.launch(Dispatchers.Default) {
+            allMasterItems.forEach {
+                if (!it.source.isUserCustom && categoryFor(it.source) == category) {
+                    it.checked = checked
+                }
+            }
+            val filtered = applyFilter(allMasterItems, _uiState.value.searchQuery)
+            val sortedAndFiltered = sortItems(filtered)
+            _uiState.value = _uiState.value.copy(
+                items = ArrayList(allMasterItems),
+                filteredItems = ArrayList(sortedAndFiltered),
                 lastUpdate = System.currentTimeMillis()
             )
         }
@@ -264,7 +282,14 @@ class PidDefinitionViewModel(
         val (userPids, standardPids) = input.partition { it.source.isUserCustom }
 
         val checkedStandard = standardPids.filter { it.checked }.toMutableList()
-        val uncheckedStandard = standardPids.filter { !it.checked }
+        // Unchecked PIDs are the "browse to add" portion of the list, so group them by category
+        // to make the large catalog easier to scan; checked PIDs keep their custom drag order.
+        val uncheckedStandard = standardPids.filter { !it.checked }.sortedWith(
+            compareBy(
+                { PID_CATEGORY_DISPLAY_ORDER.indexOf(categoryFor(it.source)) },
+                { it.source.description ?: "" }
+            )
+        )
 
         if (sortOrder == null || sortOrder.isEmpty()) {
             viewSerializer.store(checkedStandard.map { it.source.id })

--- a/app/src/main/res/drawable/bg_category_index_bar.xml
+++ b/app/src/main/res/drawable/bg_category_index_bar.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="14dp" />
+    <solid android:color="#802D2D2D" />
+</shape>

--- a/app/src/main/res/drawable/bg_category_index_bar.xml
+++ b/app/src/main/res/drawable/bg_category_index_bar.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <corners android:radius="14dp" />
-    <solid android:color="#802D2D2D" />
-</shape>

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -24,20 +24,6 @@
             android:background="@android:color/transparent" />
     </com.google.android.material.card.MaterialCardView>
 
-    <LinearLayout
-        android:id="@+id/category_index_bar"
-        android:layout_width="44dp"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/toolbar_card"
-        android:layout_above="@id/bottom_panel_card"
-        android:layout_alignParentStart="true"
-        android:layout_centerVertical="true"
-        android:layout_marginStart="2dp"
-        android:background="@drawable/bg_category_index_bar"
-        android:orientation="vertical"
-        android:padding="2dp"
-        android:visibility="gone" />
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
@@ -47,6 +33,20 @@
         android:clipToPadding="false"
         app:cardBackgroundColor="@color/dialog_card_background"
         android:paddingVertical="4dp" />
+
+    <!-- Transparent, sits aside the list rather than pushing/covering it, see
+         PidDefinitionDialogFragment.updateCategoryIndexBar. -->
+    <LinearLayout
+        android:id="@+id/category_index_bar"
+        android:layout_width="18dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/toolbar_card"
+        android:layout_above="@id/bottom_panel_card"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:clipChildren="false"
+        android:orientation="vertical"
+        android:visibility="gone" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_pid"

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -34,8 +34,9 @@
         app:cardBackgroundColor="@color/dialog_card_background"
         android:paddingVertical="4dp" />
 
-    <!-- Transparent, sits aside the list rather than pushing/covering it, see
-         PidDefinitionDialogFragment.updateCategoryIndexBar. -->
+    <!-- Sits in its own reserved column at the true left edge (see
+         PidDefinitionDialogFragment.setContentIndexBarInset), not overlapping the toolbar/list/
+         button cards, which all get pushed right by the same amount while this is visible. -->
     <LinearLayout
         android:id="@+id/category_index_bar"
         android:layout_width="18dp"
@@ -44,6 +45,7 @@
         android:layout_above="@id/bottom_panel_card"
         android:layout_alignParentStart="true"
         android:layout_centerVertical="true"
+        android:layout_marginStart="8dp"
         android:clipChildren="false"
         android:orientation="vertical"
         android:visibility="gone" />

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- The dialog window itself has a transparent background (see
+     CoreDialogFragment.requestWindowFeatures), so anything not covered by an opaque card here
+     reveals whatever screen is behind the dialog. Background covers the whole panel rather than
+     leaving that to each individual card, so the gaps between/around cards (and the category
+     header rows) don't show the Settings screen bleeding through behind them. -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/dialog_card_background">
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/toolbar_card"
@@ -36,17 +42,19 @@
 
     <!-- Sits in its own reserved column at the true left edge (see
          PidDefinitionDialogFragment.setContentIndexBarInset), not overlapping the toolbar/list/
-         button cards, which all get pushed right by the same amount while this is visible. -->
+         button cards, which all shrink by the same amount on both sides while this is visible.
+         Fills the full band between the two cards (rather than wrap_content + centerVertical,
+         which left the markers pinned to the top) and centers its children within that band. -->
     <LinearLayout
         android:id="@+id/category_index_bar"
-        android:layout_width="18dp"
-        android:layout_height="wrap_content"
+        android:layout_width="22dp"
+        android:layout_height="match_parent"
         android:layout_below="@id/toolbar_card"
         android:layout_above="@id/bottom_panel_card"
         android:layout_alignParentStart="true"
-        android:layout_centerVertical="true"
         android:layout_marginStart="8dp"
         android:clipChildren="false"
+        android:gravity="center_vertical"
         android:orientation="vertical"
         android:visibility="gone" />
 

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -34,6 +34,21 @@
         app:cardBackgroundColor="@color/dialog_card_background"
         android:paddingVertical="4dp" />
 
+    <LinearLayout
+        android:id="@+id/category_index_bar"
+        android:layout_width="30dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/toolbar_card"
+        android:layout_above="@id/bottom_panel_card"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="4dp"
+        android:background="@drawable/bg_category_index_bar"
+        android:elevation="6dp"
+        android:orientation="vertical"
+        android:padding="2dp"
+        android:visibility="gone" />
+
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_pid"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -26,7 +26,7 @@
 
     <LinearLayout
         android:id="@+id/category_index_bar"
-        android:layout_width="32dp"
+        android:layout_width="44dp"
         android:layout_height="wrap_content"
         android:layout_below="@id/toolbar_card"
         android:layout_above="@id/bottom_panel_card"

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -24,6 +24,20 @@
             android:background="@android:color/transparent" />
     </com.google.android.material.card.MaterialCardView>
 
+    <LinearLayout
+        android:id="@+id/category_index_bar"
+        android:layout_width="32dp"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/toolbar_card"
+        android:layout_above="@id/bottom_panel_card"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"
+        android:layout_marginStart="2dp"
+        android:background="@drawable/bg_category_index_bar"
+        android:orientation="vertical"
+        android:padding="2dp"
+        android:visibility="gone" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
@@ -33,21 +47,6 @@
         android:clipToPadding="false"
         app:cardBackgroundColor="@color/dialog_card_background"
         android:paddingVertical="4dp" />
-
-    <LinearLayout
-        android:id="@+id/category_index_bar"
-        android:layout_width="30dp"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/toolbar_card"
-        android:layout_above="@id/bottom_panel_card"
-        android:layout_alignParentStart="true"
-        android:layout_centerVertical="true"
-        android:layout_marginStart="4dp"
-        android:background="@drawable/bg_category_index_bar"
-        android:elevation="6dp"
-        android:orientation="vertical"
-        android:padding="2dp"
-        android:visibility="gone" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_pid"

--- a/app/src/main/res/layout/dialog_pid.xml
+++ b/app/src/main/res/layout/dialog_pid.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- The dialog window itself has a transparent background (see
-     CoreDialogFragment.requestWindowFeatures), so anything not covered by an opaque card here
-     reveals whatever screen is behind the dialog. Background covers the whole panel rather than
-     leaving that to each individual card, so the gaps between/around cards (and the category
-     header rows) don't show the Settings screen bleeding through behind them. -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/dialog_card_background">
+    android:layout_height="match_parent">
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/toolbar_card"

--- a/app/src/main/res/layout/item_pid.xml
+++ b/app/src/main/res/layout/item_pid.xml
@@ -11,10 +11,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_marginBottom="4dp"
-        android:background="@color/dialog_card_background"
         android:gravity="center_vertical"
         android:orientation="horizontal"
-        android:paddingVertical="4dp"
         android:visibility="gone">
 
         <com.google.android.material.checkbox.MaterialCheckBox

--- a/app/src/main/res/layout/item_pid.xml
+++ b/app/src/main/res/layout/item_pid.xml
@@ -11,8 +11,10 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:layout_marginBottom="4dp"
+        android:background="@color/dialog_card_background"
         android:gravity="center_vertical"
         android:orientation="horizontal"
+        android:paddingVertical="4dp"
         android:visibility="gone">
 
         <com.google.android.material.checkbox.MaterialCheckBox

--- a/app/src/main/res/layout/item_pid.xml
+++ b/app/src/main/res/layout/item_pid.xml
@@ -5,23 +5,39 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/tv_separator"
+    <LinearLayout
+        android:id="@+id/separator_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginBottom="4dp"
-        android:text="@string/pref.pid.manage_dialog.system_pids"
-        android:textAppearance="?attr/textAppearanceOverline"
-        android:textColor="?android:attr/textColorPrimary"
-        android:visibility="gone" />
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:visibility="gone">
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/category_selected"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tv_separator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:text="@string/pref.pid.manage_dialog.system_pids"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="?android:attr/textColorPrimary" />
+    </LinearLayout>
 
     <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="8dp"
-        android:layout_marginVertical="4dp"
+        android:layout_marginVertical="2dp"
         app:cardCornerRadius="12dp"
         app:cardElevation="2dp">
 
@@ -30,7 +46,8 @@
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
             android:orientation="horizontal"
-            android:padding="12dp">
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="6dp">
 
             <CheckBox
                 android:id="@+id/pid_selected"
@@ -62,7 +79,7 @@
                     android:id="@+id/pid_module"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
+                    android:layout_marginTop="1dp"
                     android:textAppearance="?attr/textAppearanceBody2"
                     android:textColor="?android:attr/textColorSecondary" />
 
@@ -70,7 +87,7 @@
                     android:id="@+id/pid_formula"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
+                    android:layout_marginTop="1dp"
                     android:textAppearance="?attr/textAppearanceBody2"
                     android:textColor="?android:attr/textColorSecondary" />
 
@@ -78,7 +95,7 @@
                     android:id="@+id/pid_alerts"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
+                    android:layout_marginTop="1dp"
                     android:textAppearance="?attr/textAppearanceBody2"
                     android:textColor="@color/cardinal"
                     android:textStyle="bold" />
@@ -87,7 +104,7 @@
                     android:id="@+id/pid_status"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
+                    android:layout_marginTop="1dp"
                     android:textAppearance="?attr/textAppearanceCaption" />
             </LinearLayout>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -178,16 +178,27 @@
     <string name="pref.pid.manage_dialog.can_header">Nagłówek CAN</string>
     <string name="pref.pid.manage_dialog.system_pids">PIDy systemowe</string>
     <string name="pref.pid.manage_dialog.selected_pids">Wybrane</string>
+    <string name="pref.pid.manage_dialog.selected_pids_short">WYB</string>
     <string name="pref.pid.manage_dialog.category_basics">Podstawowe</string>
+    <string name="pref.pid.manage_dialog.category_basics_short">POD</string>
     <string name="pref.pid.manage_dialog.category_ignition">Zapłon</string>
+    <string name="pref.pid.manage_dialog.category_ignition_short">ZAP</string>
     <string name="pref.pid.manage_dialog.category_fuel_afr">Paliwo / AFR</string>
+    <string name="pref.pid.manage_dialog.category_fuel_afr_short">AFR</string>
     <string name="pref.pid.manage_dialog.category_boost">Doładowanie</string>
+    <string name="pref.pid.manage_dialog.category_boost_short">DOL</string>
     <string name="pref.pid.manage_dialog.category_load_torque">Obciążenie / Moment</string>
+    <string name="pref.pid.manage_dialog.category_load_torque_short">MOM</string>
     <string name="pref.pid.manage_dialog.category_temperature">Temperatura</string>
+    <string name="pref.pid.manage_dialog.category_temperature_short">TEM</string>
     <string name="pref.pid.manage_dialog.category_air_intake">Powietrze / Dolot</string>
+    <string name="pref.pid.manage_dialog.category_air_intake_short">POW</string>
     <string name="pref.pid.manage_dialog.category_electrical">Elektryka</string>
+    <string name="pref.pid.manage_dialog.category_electrical_short">ELE</string>
     <string name="pref.pid.manage_dialog.category_location">Lokalizacja</string>
+    <string name="pref.pid.manage_dialog.category_location_short">LOK</string>
     <string name="pref.pid.manage_dialog.category_other">Inne</string>
+    <string name="pref.pid.manage_dialog.category_other_short">INN</string>
 
     <string name="pref.pid.manage_dialog.stable_yes">Stabilny: Tak</string>
     <string name="pref.pid.manage_dialog.stable_no">Stabilny: Nie</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -177,6 +177,17 @@
     <string name="pref.pid.manage_dialog.mode_hint">Mode (e.g. 01)</string>
     <string name="pref.pid.manage_dialog.can_header">Nagłówek CAN</string>
     <string name="pref.pid.manage_dialog.system_pids">PIDy systemowe</string>
+    <string name="pref.pid.manage_dialog.selected_pids">Wybrane</string>
+    <string name="pref.pid.manage_dialog.category_basics">Podstawowe</string>
+    <string name="pref.pid.manage_dialog.category_ignition">Zapłon</string>
+    <string name="pref.pid.manage_dialog.category_fuel_afr">Paliwo / AFR</string>
+    <string name="pref.pid.manage_dialog.category_boost">Doładowanie</string>
+    <string name="pref.pid.manage_dialog.category_load_torque">Obciążenie / Moment</string>
+    <string name="pref.pid.manage_dialog.category_temperature">Temperatura</string>
+    <string name="pref.pid.manage_dialog.category_air_intake">Powietrze / Dolot</string>
+    <string name="pref.pid.manage_dialog.category_electrical">Elektryka</string>
+    <string name="pref.pid.manage_dialog.category_location">Lokalizacja</string>
+    <string name="pref.pid.manage_dialog.category_other">Inne</string>
 
     <string name="pref.pid.manage_dialog.stable_yes">Stabilny: Tak</string>
     <string name="pref.pid.manage_dialog.stable_no">Stabilny: Nie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,17 @@
     <string name="pref.pid.manage_dialog.can_header">CAN Request Header</string>
     <string name="pref.pid.manage_dialog.mode_hint">Mode (e.g. 01)</string>
     <string name="pref.pid.manage_dialog.system_pids">System PIDs</string>
+    <string name="pref.pid.manage_dialog.selected_pids">Selected</string>
+    <string name="pref.pid.manage_dialog.category_basics">Basics</string>
+    <string name="pref.pid.manage_dialog.category_ignition">Ignition</string>
+    <string name="pref.pid.manage_dialog.category_fuel_afr">Fuel / AFR</string>
+    <string name="pref.pid.manage_dialog.category_boost">Boost</string>
+    <string name="pref.pid.manage_dialog.category_load_torque">Load / Torque</string>
+    <string name="pref.pid.manage_dialog.category_temperature">Temperature</string>
+    <string name="pref.pid.manage_dialog.category_air_intake">Air / Intake</string>
+    <string name="pref.pid.manage_dialog.category_electrical">Electrical</string>
+    <string name="pref.pid.manage_dialog.category_location">Location</string>
+    <string name="pref.pid.manage_dialog.category_other">Other</string>
 
     <string name="pref.displayed_parameter_ids">Customize visible OBD2 PIDs</string>
     <string name="pref.displayed_parameter_ids_summary">Pick the OBD2 sensors or PIDs you would like to view on the screen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,16 +97,27 @@
     <string name="pref.pid.manage_dialog.mode_hint">Mode (e.g. 01)</string>
     <string name="pref.pid.manage_dialog.system_pids">System PIDs</string>
     <string name="pref.pid.manage_dialog.selected_pids">Selected</string>
+    <string name="pref.pid.manage_dialog.selected_pids_short">SEL</string>
     <string name="pref.pid.manage_dialog.category_basics">Basics</string>
+    <string name="pref.pid.manage_dialog.category_basics_short">BAS</string>
     <string name="pref.pid.manage_dialog.category_ignition">Ignition</string>
+    <string name="pref.pid.manage_dialog.category_ignition_short">IGN</string>
     <string name="pref.pid.manage_dialog.category_fuel_afr">Fuel / AFR</string>
+    <string name="pref.pid.manage_dialog.category_fuel_afr_short">AFR</string>
     <string name="pref.pid.manage_dialog.category_boost">Boost</string>
+    <string name="pref.pid.manage_dialog.category_boost_short">BST</string>
     <string name="pref.pid.manage_dialog.category_load_torque">Load / Torque</string>
+    <string name="pref.pid.manage_dialog.category_load_torque_short">TRQ</string>
     <string name="pref.pid.manage_dialog.category_temperature">Temperature</string>
+    <string name="pref.pid.manage_dialog.category_temperature_short">TMP</string>
     <string name="pref.pid.manage_dialog.category_air_intake">Air / Intake</string>
+    <string name="pref.pid.manage_dialog.category_air_intake_short">AIR</string>
     <string name="pref.pid.manage_dialog.category_electrical">Electrical</string>
+    <string name="pref.pid.manage_dialog.category_electrical_short">ELE</string>
     <string name="pref.pid.manage_dialog.category_location">Location</string>
+    <string name="pref.pid.manage_dialog.category_location_short">LOC</string>
     <string name="pref.pid.manage_dialog.category_other">Other</string>
+    <string name="pref.pid.manage_dialog.category_other_short">OTH</string>
 
     <string name="pref.displayed_parameter_ids">Customize visible OBD2 PIDs</string>
     <string name="pref.displayed_parameter_ids_summary">Pick the OBD2 sensors or PIDs you would like to view on the screen</string>


### PR DESCRIPTION
Ports the same keyword-based signal grouping used in the web log viewer's sidebar to the Android PID picker. Unchecked PIDs are grouped under category headers (Basics, Ignition, Fuel/AFR, Boost, etc.) with a tri-state checkbox to select a whole category at once; all checked PIDs are collected under a single "Selected" header at the top so they read as one group while keeping their custom drag order. Category headers also got a bigger font and PID cards a tighter layout.