### PR TITLE
feat(pid-picker): dim window scrim, style category headers, fix grouping

### DIFF
--- a/app/src/main/java/org/obd/graphs/preferences/CoreDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/CoreDialogFragment.kt
@@ -25,9 +25,9 @@ import androidx.fragment.app.DialogFragment
 import org.obd.graphs.R
 
 abstract class CoreDialogFragment : DialogFragment() {
-    protected fun requestWindowFeatures() {
+    protected fun requestWindowFeatures(scrimColor: Int = Color.TRANSPARENT) {
         dialog?.let {
-            it.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            it.window?.setBackgroundDrawable(ColorDrawable(scrimColor))
             it.window?.requestFeature(Window.FEATURE_NO_TITLE)
         }
     }

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidCategory.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidCategory.kt
@@ -28,8 +28,9 @@ enum class PidCategory(val stringRes: Int, val shortStringRes: Int) {
     LOAD_TORQUE(R.string.pref_pid_manage_dialog_category_load_torque, R.string.pref_pid_manage_dialog_category_load_torque_short),
     TEMPERATURE(R.string.pref_pid_manage_dialog_category_temperature, R.string.pref_pid_manage_dialog_category_temperature_short),
     AIR_INTAKE(R.string.pref_pid_manage_dialog_category_air_intake, R.string.pref_pid_manage_dialog_category_air_intake_short),
-    ELECTRICAL(R.string.pref_pid_manage_dialog_category_electrical, R.string.pref_pid_manage_dialog_category_electrical_short),
     LOCATION(R.string.pref_pid_manage_dialog_category_location, R.string.pref_pid_manage_dialog_category_location_short),
+    IBS(R.string.pref_pid_manage_dialog_category_ibs, R.string.pref_pid_manage_dialog_category_ibs_short),
+    OIL(R.string.pref_pid_manage_dialog_category_oil, R.string.pref_pid_manage_dialog_category_oil_short),
     OTHER(R.string.pref_pid_manage_dialog_category_other, R.string.pref_pid_manage_dialog_category_other_short)
 }
 
@@ -43,26 +44,31 @@ val PID_CATEGORY_DISPLAY_ORDER: List<PidCategory> = listOf(
     PidCategory.LOAD_TORQUE,
     PidCategory.TEMPERATURE,
     PidCategory.AIR_INTAKE,
-    PidCategory.ELECTRICAL,
     PidCategory.LOCATION,
+    PidCategory.IBS,
+    PidCategory.OIL,
     PidCategory.OTHER
 )
 
 private data class CategoryRule(val category: PidCategory, val pattern: Regex)
 
 // Ordered most-specific first, e.g. "O2 Voltage" must match FUEL_AFR before the generic
-// "voltage" keyword in ELECTRICAL, and "Calculated horse power" must match LOAD_TORQUE.
+// "voltage" keyword in IBS, and "Calculated horse power" must match LOAD_TORQUE.
 private val RULES: List<CategoryRule> = listOf(
-    CategoryRule(PidCategory.IGNITION, Regex("spark|ignition|timing adv|misfire", RegexOption.IGNORE_CASE)),
+    // Checked first: IAM/IBS readings also mention words like "battery" and "boost status" that
+    // would otherwise be claimed by the BOOST rule below.
+    CategoryRule(PidCategory.IBS, Regex("\\biam\\b|\\bibs\\b|voltage|battery", RegexOption.IGNORE_CASE)),
+    CategoryRule(PidCategory.IGNITION, Regex("spark|ignition|timing adv|misfire|knock|coil|injection", RegexOption.IGNORE_CASE)),
+    // Word-bounded so it doesn't match inside "coil" (already claimed by IGNITION above).
+    CategoryRule(PidCategory.OIL, Regex("\\boil\\b", RegexOption.IGNORE_CASE)),
     CategoryRule(PidCategory.FUEL_AFR, Regex("\\bafr\\b|lambda|fuel|air.?fuel|\\bo2\\b|oxygen", RegexOption.IGNORE_CASE)),
     CategoryRule(
         PidCategory.BOOST,
-        Regex("boost|wastegate|turbo|manifold|intake pressure|\\bmap\\b|atmospheric|baro", RegexOption.IGNORE_CASE)
+        Regex("boost|wastegate|turbo|manifold|intake pressure|\\bmap\\b|atmospheric|baro|throttle position|throttle angle", RegexOption.IGNORE_CASE)
     ),
     CategoryRule(PidCategory.LOAD_TORQUE, Regex("torque|\\bload\\b|horsepower|horse power|\\bhp\\b", RegexOption.IGNORE_CASE)),
     CategoryRule(PidCategory.TEMPERATURE, Regex("temp", RegexOption.IGNORE_CASE)),
     CategoryRule(PidCategory.AIR_INTAKE, Regex("\\bair\\b|\\bmaf\\b|flow", RegexOption.IGNORE_CASE)),
-    CategoryRule(PidCategory.ELECTRICAL, Regex("voltage|battery|\\bibs\\b|oil level|oil degradation", RegexOption.IGNORE_CASE)),
     CategoryRule(PidCategory.LOCATION, Regex("latitude|longitude|\\blat\\b|\\blon\\b|\\blng\\b|gps", RegexOption.IGNORE_CASE)),
     CategoryRule(PidCategory.BASICS, Regex("speed|\\brpm\\b|pedal|throttle|gear|selector|distance|odometer", RegexOption.IGNORE_CASE))
 )
@@ -71,7 +77,9 @@ private val RULES: List<CategoryRule> = listOf(
 // categorization is inferred from the PID's description text, same approach as the web log
 // viewer's signal-categories.ts.
 fun categoryFor(pid: PidDefinition): PidCategory {
-    val text = "${pid.description ?: ""} ${pid.longDescription ?: ""}"
+    // Descriptions in the PID JSON sources often wrap onto multiple lines (e.g. "Measured
+    // Intake\nPressure"), which would otherwise break multi-word keywords like "intake pressure".
+    val text = "${pid.description ?: ""} ${pid.longDescription ?: ""}".replace('\n', ' ')
     for (rule in RULES) {
         if (rule.pattern.containsMatchIn(text)) return rule.category
     }

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionDialogFragment.kt
@@ -34,6 +34,7 @@ import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -81,7 +82,7 @@ open class PidDefinitionDialogFragment(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        requestWindowFeatures()
+        requestWindowFeatures(scrimColor = ContextCompat.getColor(requireContext(), R.color.dialog_scrim))
         root = inflater.inflate(R.layout.dialog_pid, container, false)
 
         val adapter = PidDefinitionViewAdapter(

--- a/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewAdapter.kt
+++ b/app/src/main/java/org/obd/graphs/preferences/pid/PidDefinitionViewAdapter.kt
@@ -74,7 +74,9 @@ class PidDefinitionViewAdapter internal constructor(
                 when (section) {
                     is PidSection.Selected -> {
                         holder.separator.text = context?.getString(R.string.pref_pid_manage_dialog_selected_pids)
-                        holder.categorySelect.visibility = View.GONE
+                        // INVISIBLE (not GONE): keeps the same start offset as category headers
+                        // that do show a checkbox, so "Selected" doesn't sit at a different indent.
+                        holder.categorySelect.visibility = View.INVISIBLE
                         holder.categorySelect.setOnClickListener(null)
                     }
                     is PidSection.Category -> {

--- a/app/src/main/res/color/category_checkbox_tint.xml
+++ b/app/src/main/res/color/category_checkbox_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/philippine_green" android:state_checked="true" />
+    <item android:color="@color/dialog_text_primary" />
+</selector>

--- a/app/src/main/res/drawable/bg_category_header_pill.xml
+++ b/app/src/main/res/drawable/bg_category_header_pill.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/philippine_green" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/src/main/res/layout/item_pid.xml
+++ b/app/src/main/res/layout/item_pid.xml
@@ -20,6 +20,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
+            app:buttonTint="@color/category_checkbox_tint"
             android:visibility="gone" />
 
         <TextView
@@ -27,10 +28,13 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
+            android:background="@drawable/bg_category_header_pill"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="4dp"
             android:text="@string/pref.pid.manage_dialog.system_pids"
             android:textSize="18sp"
             android:textStyle="bold"
-            android:textColor="?android:attr/textColorPrimary" />
+            android:textColor="@android:color/white" />
     </LinearLayout>
 
     <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -4,6 +4,7 @@
     <color name="dialog_text_secondary">#A1A1AA</color>
 
     <color name="dialog_card_background">#1E1E1E</color>
+    <color name="dialog_scrim">#80202020</color>
 
     <color name="philippine_green">#4ADE80</color>
     <color name="rainbow_indigo">#818CF8</color>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -193,8 +193,6 @@
     <string name="pref.pid.manage_dialog.category_temperature_short">TEM</string>
     <string name="pref.pid.manage_dialog.category_air_intake">Powietrze / Dolot</string>
     <string name="pref.pid.manage_dialog.category_air_intake_short">POW</string>
-    <string name="pref.pid.manage_dialog.category_electrical">Elektryka</string>
-    <string name="pref.pid.manage_dialog.category_electrical_short">ELE</string>
     <string name="pref.pid.manage_dialog.category_location">Lokalizacja</string>
     <string name="pref.pid.manage_dialog.category_location_short">LOK</string>
     <string name="pref.pid.manage_dialog.category_other">Inne</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -195,6 +195,10 @@
     <string name="pref.pid.manage_dialog.category_air_intake_short">POW</string>
     <string name="pref.pid.manage_dialog.category_location">Lokalizacja</string>
     <string name="pref.pid.manage_dialog.category_location_short">LOK</string>
+    <string name="pref.pid.manage_dialog.category_ibs">IBS</string>
+    <string name="pref.pid.manage_dialog.category_ibs_short">IBS</string>
+    <string name="pref.pid.manage_dialog.category_oil">Olej</string>
+    <string name="pref.pid.manage_dialog.category_oil_short">OLE</string>
     <string name="pref.pid.manage_dialog.category_other">Inne</string>
     <string name="pref.pid.manage_dialog.category_other_short">INN</string>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,6 +4,7 @@
     <color name="dialog_text_secondary">#757575</color>
     <color name="dynamic_selector_sport">#FFFF4444</color>
     <color name="dialog_card_background">#F0F2F5</color>
+    <color name="dialog_scrim">#80AAAAAA</color>
     <color name="white">#FFFFFF</color>
     <color name="black">#000000</color>
     <color name="rainbow_indigo">#1C3D72</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -112,10 +112,12 @@
     <string name="pref.pid.manage_dialog.category_temperature_short">TMP</string>
     <string name="pref.pid.manage_dialog.category_air_intake">Air / Intake</string>
     <string name="pref.pid.manage_dialog.category_air_intake_short">AIR</string>
-    <string name="pref.pid.manage_dialog.category_electrical">Electrical</string>
-    <string name="pref.pid.manage_dialog.category_electrical_short">ELE</string>
     <string name="pref.pid.manage_dialog.category_location">Location</string>
     <string name="pref.pid.manage_dialog.category_location_short">LOC</string>
+    <string name="pref.pid.manage_dialog.category_ibs">IBS</string>
+    <string name="pref.pid.manage_dialog.category_ibs_short">IBS</string>
+    <string name="pref.pid.manage_dialog.category_oil">Oil</string>
+    <string name="pref.pid.manage_dialog.category_oil_short">OIL</string>
     <string name="pref.pid.manage_dialog.category_other">Other</string>
     <string name="pref.pid.manage_dialog.category_other_short">OTH</string>
 


### PR DESCRIPTION
- Dialog window background: theme-aware translucent scrim (dialog_scrim color) instead of fully transparent, so Settings screen no longer bleeds through behind the picker.
- Category header rows in the list now use the same green pill style as the active vertical index-bar marker, instead of plain text.
- "Selected" header checkbox switched from GONE to INVISIBLE so its indent matches the other category headers.
- category_selected checkbox given an explicit theme-aware tint (previously washed out/near-invisible in light theme).
- PID category grouping (PidCategory.kt) overhaul:
  - normalize newlines in PID descriptions before keyword matching (fixes "Measured Intake\nPressure" not matching "intake pressure")
  - add Knock/Coil/Injection keywords to Ignition
  - add Throttle position/angle keywords to Boost
  - new IBS category (renamed from IAM) for IAM:/IBS PIDs
  - new Oil category, split out of Electrical/Temperature/Other
  - remove Electrical (down to one item), fold voltage/battery into IBS